### PR TITLE
Update from `sql=` to `query=` throughout the compliance

### DIFF
--- a/controls/apigateway.sp
+++ b/controls/apigateway.sp
@@ -16,14 +16,14 @@ benchmark "apigateway" {
   ]
 
   tags = merge(local.apigateway_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "apigateway_rest_api_stage_use_ssl_certificate" {
   title       = "API Gateway stage should uses SSL certificate"
   description = "Ensure if a REST API stage uses a Secure Sockets Layer (SSL) certificate. This rule is complaint if the REST API stage does not have an associated SSL certificate."
-  sql           = query.apigateway_rest_api_stage_use_ssl_certificate.sql
+  query       = query.apigateway_rest_api_stage_use_ssl_certificate
 
   tags = merge(local.apigateway_compliance_common_tags, {
     rbi_cyber_security = "true"
@@ -31,9 +31,9 @@ control "apigateway_rest_api_stage_use_ssl_certificate" {
 }
 
 control "apigateway_rest_api_stage_xray_tracing_enabled" {
-  title        = "API Gateway REST API stages should have AWS X-Ray tracing enabled"
-  description  = "This control checks whether AWS X-Ray active tracing is enabled for your Amazon API Gateway REST API stages."
-  sql           = query.apigateway_rest_api_stage_xray_tracing_enabled.sql
+  title       = "API Gateway REST API stages should have AWS X-Ray tracing enabled"
+  description = "This control checks whether AWS X-Ray active tracing is enabled for your Amazon API Gateway REST API stages."
+  query       = query.apigateway_rest_api_stage_xray_tracing_enabled
 
   tags = merge(local.apigateway_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -41,9 +41,9 @@ control "apigateway_rest_api_stage_xray_tracing_enabled" {
 }
 
 control "apigateway_stage_cache_encryption_at_rest_enabled" {
-  title         = "API Gateway REST API cache data should be encrypted at rest"
-  description   = "This control checks whether all methods in API Gateway REST API stages that have cache enabled are encrypted. The control fails if any method in an API Gateway REST API stage is configured to cache and the cache is not encrypted."
-  sql           = query.apigateway_stage_cache_encryption_at_rest_enabled.sql
+  title       = "API Gateway REST API cache data should be encrypted at rest"
+  description = "This control checks whether all methods in API Gateway REST API stages that have cache enabled are encrypted. The control fails if any method in an API Gateway REST API stage is configured to cache and the cache is not encrypted."
+  query       = query.apigateway_stage_cache_encryption_at_rest_enabled
 
   tags = merge(local.apigateway_compliance_common_tags, {
     gdpr               = "true"
@@ -55,9 +55,9 @@ control "apigateway_stage_cache_encryption_at_rest_enabled" {
 }
 
 control "apigateway_stage_logging_enabled" {
-  title         = "API Gateway REST and WebSocket API logging should be enabled"
-  description   = "This control checks whether all stages of an Amazon API Gateway REST or WebSocket API have logging enabled. The control fails if logging is not enabled for all methods of a stage or if loggingLevel is neither ERROR nor INFO."
-  sql           = query.apigateway_stage_logging_enabled.sql
+  title       = "API Gateway REST and WebSocket API logging should be enabled"
+  description = "This control checks whether all stages of an Amazon API Gateway REST or WebSocket API have logging enabled. The control fails if logging is not enabled for all methods of a stage or if loggingLevel is neither ERROR nor INFO."
+  query       = query.apigateway_stage_logging_enabled
 
   tags = merge(local.apigateway_compliance_common_tags, {
     hipaa              = "true"

--- a/controls/athena.sp
+++ b/controls/athena.sp
@@ -14,14 +14,14 @@ benchmark "athena" {
   ]
 
   tags = merge(local.athena_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "athena_database_encryption_at_rest_enabled" {
   title       = "Athena database encryption at rest should be enabled"
   description = "Ensure Athena database is encrypted at rest to protect sensitive data."
-  sql           = query.athena_database_encryption_at_rest_enabled.sql
+  query       = query.athena_database_encryption_at_rest_enabled
 
   tags = local.athena_compliance_common_tags
 
@@ -30,7 +30,7 @@ control "athena_database_encryption_at_rest_enabled" {
 control "athena_workgroup_encryption_at_rest_enabled" {
   title       = "Athena workgroup encryption at rest should be enabled"
   description = "Ensure Athena workgroup is encrypted at rest to protect sensitive data."
-  sql           = query.athena_workgroup_encryption_at_rest_enabled.sql
+  query       = query.athena_workgroup_encryption_at_rest_enabled
 
   tags = local.athena_compliance_common_tags
 

--- a/controls/autoscaling.sp
+++ b/controls/autoscaling.sp
@@ -14,14 +14,14 @@ benchmark "autoscaling" {
   ]
 
   tags = merge(local.autoscaling_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "autoscaling_group_with_lb_use_health_check" {
-  title         = "Auto Scaling groups with a load balancer should use health checks"
-  description   = "The Elastic Load Balancer (ELB) health checks for Amazon Elastic Compute Cloud (Amazon EC2) Auto Scaling groups that support maintenance of adequate capacity and availability."
-  sql           = query.autoscaling_group_with_lb_use_health_check.sql
+  title       = "Auto Scaling groups with a load balancer should use health checks"
+  description = "The Elastic Load Balancer (ELB) health checks for Amazon Elastic Compute Cloud (Amazon EC2) Auto Scaling groups that support maintenance of adequate capacity and availability."
+  query       = query.autoscaling_group_with_lb_use_health_check
 
   tags = merge(local.autoscaling_compliance_common_tags, {
     hipaa             = "true"
@@ -31,9 +31,9 @@ control "autoscaling_group_with_lb_use_health_check" {
 }
 
 control "autoscaling_launch_config_public_ip_disabled" {
-  title         = "Auto Scaling launch config public IP should be disabled"
-  description   = "Ensure if Amazon EC2 Auto Scaling groups have public IP addresses enabled through Launch Configurations. This rule is non complaint if the Launch Configuration for an Auto Scaling group has AssociatePublicIpAddress set to 'true'."
-  sql           = query.autoscaling_launch_config_public_ip_disabled.sql
+  title       = "Auto Scaling launch config public IP should be disabled"
+  description = "Ensure if Amazon EC2 Auto Scaling groups have public IP addresses enabled through Launch Configurations. This rule is non complaint if the Launch Configuration for an Auto Scaling group has AssociatePublicIpAddress set to 'true'."
+  query       = query.autoscaling_launch_config_public_ip_disabled
 
   tags = merge(local.autoscaling_compliance_common_tags, {
     rbi_cyber_security = "true"

--- a/controls/backup.sp
+++ b/controls/backup.sp
@@ -13,14 +13,14 @@ benchmark "backup" {
   ]
 
   tags = merge(local.backup_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "backup_plan_min_retention_35_days" {
-  title         = "Backup plan min frequency and min retention check"
-  description   = "Checks if a backup plan has a backup rule that satisfies the required frequency and retention period(35 days). The rule is non complaint if recovery points are not created at least as often as the specified frequency or expire before the specified period."
-  sql           = query.backup_plan_min_retention_35_days.sql
+  title       = "Backup plan min frequency and min retention check"
+  description = "Checks if a backup plan has a backup rule that satisfies the required frequency and retention period(35 days). The rule is non complaint if recovery points are not created at least as often as the specified frequency or expire before the specified period."
+  query       = query.backup_plan_min_retention_35_days
 
   tags = merge(local.backup_compliance_common_tags, {
     hipaa    = "true"

--- a/controls/cloudfront.sp
+++ b/controls/cloudfront.sp
@@ -5,8 +5,8 @@ locals {
 }
 
 benchmark "cloudfront" {
-  title        = "CloudFront"
-  description  = "This benchmark provides a set of controls that detect Terraform AWS CloudFront resources deviating from security best practices."
+  title       = "CloudFront"
+  description = "This benchmark provides a set of controls that detect Terraform AWS CloudFront resources deviating from security best practices."
 
   children = [
     control.cloudfront_distribution_configured_with_origin_failover,
@@ -19,14 +19,14 @@ benchmark "cloudfront" {
   ]
 
   tags = merge(local.cloudfront_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "cloudfront_distribution_configured_with_origin_failover" {
-  title         = "CloudFront distributions should have origin failover configured"
-  description   = "This control checks whether an Amazon CloudFront distribution is configured with an origin group that has two or more origins. CloudFront origin failover can increase availability. Origin failover automatically redirects traffic to a secondary origin if the primary origin is unavailable or if it returns specific HTTP response status codes."
-  sql           = query.cloudfront_distribution_configured_with_origin_failover.sql
+  title       = "CloudFront distributions should have origin failover configured"
+  description = "This control checks whether an Amazon CloudFront distribution is configured with an origin group that has two or more origins. CloudFront origin failover can increase availability. Origin failover automatically redirects traffic to a secondary origin if the primary origin is unavailable or if it returns specific HTTP response status codes."
+  query       = query.cloudfront_distribution_configured_with_origin_failover
 
   tags = merge(local.cloudfront_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -34,9 +34,9 @@ control "cloudfront_distribution_configured_with_origin_failover" {
 }
 
 control "cloudfront_distribution_default_root_object_configured" {
-  title         = "CloudFront distributions should have a default root object configured"
-  description   = "This control checks whether an Amazon CloudFront distribution is configured to return a specific object that is the default root object. The control fails if the CloudFront distribution does not have a default root object configured."
-  sql           = query.cloudfront_distribution_default_root_object_configured.sql
+  title       = "CloudFront distributions should have a default root object configured"
+  description = "This control checks whether an Amazon CloudFront distribution is configured to return a specific object that is the default root object. The control fails if the CloudFront distribution does not have a default root object configured."
+  query       = query.cloudfront_distribution_default_root_object_configured
 
   tags = merge(local.cloudfront_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -44,9 +44,9 @@ control "cloudfront_distribution_default_root_object_configured" {
 }
 
 control "cloudfront_distribution_encryption_in_transit_enabled" {
-  title         = "CloudFront distributions should require encryption in transit"
-  description   = "This control checks whether an Amazon CloudFront distribution requires viewers to use HTTPS directly or whether it uses redirection. The control fails if ViewerProtocolPolicy is set to allow-all for defaultCacheBehavior or for cacheBehaviors."
-  sql           = query.cloudfront_distribution_encryption_in_transit_enabled.sql
+  title       = "CloudFront distributions should require encryption in transit"
+  description = "This control checks whether an Amazon CloudFront distribution requires viewers to use HTTPS directly or whether it uses redirection. The control fails if ViewerProtocolPolicy is set to allow-all for defaultCacheBehavior or for cacheBehaviors."
+  query       = query.cloudfront_distribution_encryption_in_transit_enabled
 
   tags = merge(local.cloudfront_compliance_common_tags, {
     gdpr  = "true"
@@ -55,9 +55,9 @@ control "cloudfront_distribution_encryption_in_transit_enabled" {
 }
 
 control "cloudfront_distribution_logging_enabled" {
-  title         = "CloudFront distributions should have logging enabled"
-  description   = "This control checks whether server access logging is enabled on CloudFront distributions. The control fails if access logging is not enabled for a distribution."
-  sql           = query.cloudfront_distribution_logging_enabled.sql
+  title       = "CloudFront distributions should have logging enabled"
+  description = "This control checks whether server access logging is enabled on CloudFront distributions. The control fails if access logging is not enabled for a distribution."
+  query       = query.cloudfront_distribution_logging_enabled
 
   tags = merge(local.cloudfront_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -65,9 +65,9 @@ control "cloudfront_distribution_logging_enabled" {
 }
 
 control "cloudfront_distribution_origin_access_identity_enabled" {
-  title         = "CloudFront distributions should have origin access identity enabled"
-  description   = "This control checks whether an Amazon CloudFront distribution with Amazon S3 Origin type has Origin Access Identity (OAI) configured. The control fails if OAI is not configured."
-  sql           = query.cloudfront_distribution_origin_access_identity_enabled.sql
+  title       = "CloudFront distributions should have origin access identity enabled"
+  description = "This control checks whether an Amazon CloudFront distribution with Amazon S3 Origin type has Origin Access Identity (OAI) configured. The control fails if OAI is not configured."
+  query       = query.cloudfront_distribution_origin_access_identity_enabled
 
   tags = merge(local.cloudfront_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -75,9 +75,9 @@ control "cloudfront_distribution_origin_access_identity_enabled" {
 }
 
 control "cloudfront_distribution_waf_enabled" {
-  title         = "CloudFront distributions should have AWS WAF enabled"
-  description   = "This control checks whether CloudFront distributions are associated with either AWS WAF or AWS WAFv2 web ACLs. The control fails if the distribution is not associated with a web ACL."
-  sql           = query.cloudfront_distribution_waf_enabled.sql
+  title       = "CloudFront distributions should have AWS WAF enabled"
+  description = "This control checks whether CloudFront distributions are associated with either AWS WAF or AWS WAFv2 web ACLs. The control fails if the distribution is not associated with a web ACL."
+  query       = query.cloudfront_distribution_waf_enabled
 
   tags = merge(local.cloudfront_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -87,7 +87,7 @@ control "cloudfront_distribution_waf_enabled" {
 control "cloudfront_protocol_version_is_low" {
   title       = "CloudFront distributions minimum protocol version should be set"
   description = "CloudFront distributions minimum protocol version should be a good one. Minimum recommended version is TLSv1.2_2019."
-  sql         = query.cloudfront_protocol_version_is_low.sql
+  query       = query.cloudfront_protocol_version_is_low
 
   tags = local.cloudfront_compliance_common_tags
 }

--- a/controls/cloudtrail.sp
+++ b/controls/cloudtrail.sp
@@ -5,8 +5,8 @@ locals {
 }
 
 benchmark "cloudtrail" {
-  title        = "CloudTrail"
-  description  = "This benchmark provides a set of controls that detect Terraform AWS CloudTrail resources deviating from security best practices."
+  title       = "CloudTrail"
+  description = "This benchmark provides a set of controls that detect Terraform AWS CloudTrail resources deviating from security best practices."
 
   children = [
     control.cloudtrail_enabled_all_regions,
@@ -15,14 +15,14 @@ benchmark "cloudtrail" {
   ]
 
   tags = merge(local.cloudtrail_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "cloudtrail_enabled_all_regions" {
-  title         = "Ensure CloudTrail is enabled in all regions"
-  description   = "CloudTrail is a service that records AWS API calls for your account and delivers log files to you. The recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the AWS service."
-  sql           = query.cloudtrail_enabled_all_regions.sql
+  title       = "Ensure CloudTrail is enabled in all regions"
+  description = "CloudTrail is a service that records AWS API calls for your account and delivers log files to you. The recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the AWS service."
+  query       = query.cloudtrail_enabled_all_regions
 
   tags = merge(local.cloudtrail_compliance_common_tags, {
     cis  = "true"
@@ -32,9 +32,9 @@ control "cloudtrail_enabled_all_regions" {
 }
 
 control "cloudtrail_trail_logs_encrypted_with_kms_cmk" {
-  title         = "CloudTrail trail logs should be encrypted with KMS CMK"
-  description   = "To help protect sensitive data at rest, ensure encryption is enabled for your Amazon CloudWatch Log Groups."
-  sql           = query.cloudtrail_trail_logs_encrypted_with_kms_cmk.sql
+  title       = "CloudTrail trail logs should be encrypted with KMS CMK"
+  description = "To help protect sensitive data at rest, ensure encryption is enabled for your Amazon CloudWatch Log Groups."
+  query       = query.cloudtrail_trail_logs_encrypted_with_kms_cmk
 
   tags = merge(local.cloudtrail_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -44,14 +44,14 @@ control "cloudtrail_trail_logs_encrypted_with_kms_cmk" {
     nist_800_53_rev_4         = "true"
     nist_csf                  = "true"
     pci                       = "true"
-    rbi_cyber_security         = "true"
+    rbi_cyber_security        = "true"
   })
 }
 
 control "cloudtrail_trail_validation_enabled" {
-  title         = "CloudTrail trail log file validation should be enabled"
-  description   = "Utilize AWS CloudTrail log file validation to check the integrity of CloudTrail logs. Log file validation helps determine if a log file was modified or deleted or unchanged after CloudTrail delivered it. This feature is built using industry standard algorithms: SHA-256 for hashing and SHA-256 with RSA for digital signing. This makes it computationally infeasible to modify, delete or forge CloudTrail log files without detection."
-  sql           = query.cloudtrail_trail_validation_enabled.sql
+  title       = "CloudTrail trail log file validation should be enabled"
+  description = "Utilize AWS CloudTrail log file validation to check the integrity of CloudTrail logs. Log file validation helps determine if a log file was modified or deleted or unchanged after CloudTrail delivered it. This feature is built using industry standard algorithms: SHA-256 for hashing and SHA-256 with RSA for digital signing. This makes it computationally infeasible to modify, delete or forge CloudTrail log files without detection."
+  query       = query.cloudtrail_trail_validation_enabled
 
   tags = merge(local.cloudtrail_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/cloudwatch.sp
+++ b/controls/cloudwatch.sp
@@ -5,8 +5,8 @@ locals {
 }
 
 benchmark "cloudwatch" {
-  title        = "CloudWatch"
-  description  = "This benchmark provides a set of controls that detect Terraform AWS CloudWatch resources deviating from security best practices."
+  title       = "CloudWatch"
+  description = "This benchmark provides a set of controls that detect Terraform AWS CloudWatch resources deviating from security best practices."
 
   children = [
     control.cloudwatch_alarm_action_enabled,
@@ -16,14 +16,14 @@ benchmark "cloudwatch" {
   ]
 
   tags = merge(local.cloudwatch_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "cloudwatch_alarm_action_enabled" {
-  title         = "CloudWatch alarm action should be enabled"
-  description   = "Amazon CloudWatch alarms alert when a metric breaches the threshold for a specified number of evaluation periods. The alarm performs one or more actions based on the value of the metric or expression relative to a threshold over a number of time periods."
-  sql           = query.cloudwatch_alarm_action_enabled.sql
+  title       = "CloudWatch alarm action should be enabled"
+  description = "Amazon CloudWatch alarms alert when a metric breaches the threshold for a specified number of evaluation periods. The alarm performs one or more actions based on the value of the metric or expression relative to a threshold over a number of time periods."
+  query       = query.cloudwatch_alarm_action_enabled
 
   tags = merge(local.cloudwatch_compliance_common_tags, {
     hipaa             = "true"
@@ -34,17 +34,17 @@ control "cloudwatch_alarm_action_enabled" {
 }
 
 control "cloudwatch_destination_policy_wildcards" {
-  title         = "Ensure CloudWatch Logs destination policy has no wildcards"
-  description   = "Amazon CloudWatch Logs destination policy should avoid wildcard in 'principals' and 'actions'."
-  sql           = query.cloudwatch_destination_policy_wildcards.sql
+  title       = "Ensure CloudWatch Logs destination policy has no wildcards"
+  description = "Amazon CloudWatch Logs destination policy should avoid wildcard in 'principals' and 'actions'."
+  query       = query.cloudwatch_destination_policy_wildcards
 
   tags = local.cloudwatch_compliance_common_tags
 }
 
 control "cloudwatch_log_group_retention_period_365" {
-  title         = "Log group retention period should be at least 365 days"
-  description   = "Ensure a minimum duration of event log data is retained for your log groups to help with troubleshooting and forensics investigations."
-  sql           = query.cloudwatch_log_group_retention_period_365.sql
+  title       = "Log group retention period should be at least 365 days"
+  description = "Ensure a minimum duration of event log data is retained for your log groups to help with troubleshooting and forensics investigations."
+  query       = query.cloudwatch_log_group_retention_period_365
 
   tags = merge(local.cloudwatch_compliance_common_tags, {
     hipaa              = "true"
@@ -55,11 +55,11 @@ control "cloudwatch_log_group_retention_period_365" {
 }
 
 control "log_group_encryption_at_rest_enabled" {
-  title         = "Log group encryption at rest should be enabled"
-  description   = "To help protect sensitive data at rest, ensure encryption is enabled for your Amazon CloudWatch Log Group."
-  sql           = query.log_group_encryption_at_rest_enabled.sql
+  title       = "Log group encryption at rest should be enabled"
+  description = "To help protect sensitive data at rest, ensure encryption is enabled for your Amazon CloudWatch Log Group."
+  query       = query.log_group_encryption_at_rest_enabled
 
-   tags = merge(local.cloudwatch_compliance_common_tags, {
+  tags = merge(local.cloudwatch_compliance_common_tags, {
     gdpr               = "true"
     hipaa              = "true"
     nist_800_53_rev_4  = "true"

--- a/controls/codebuild.sp
+++ b/controls/codebuild.sp
@@ -5,8 +5,8 @@ locals {
 }
 
 benchmark "codebuild" {
-  title        = "CodeBuild"
-  description  = "This benchmark provides a set of controls that detect Terraform AWS CodeBuild resources deviating from security best practices."
+  title       = "CodeBuild"
+  description = "This benchmark provides a set of controls that detect Terraform AWS CodeBuild resources deviating from security best practices."
 
   children = [
     control.codebuild_project_encryption_at_rest_enabled,
@@ -15,14 +15,14 @@ benchmark "codebuild" {
   ]
 
   tags = merge(local.codebuild_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "codebuild_project_plaintext_env_variables_no_sensitive_aws_values" {
-  title         = "CodeBuild project plaintext environment variables should not contain sensitive AWS values"
-  description   = "Ensure authentication credentials AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY do not exist within AWS CodeBuild project environments. Do not store these variables in clear text. Storing these variables in clear text leads to unintended data exposure and unauthorized access."
-  sql           = query.codebuild_project_plaintext_env_variables_no_sensitive_aws_values.sql
+  title       = "CodeBuild project plaintext environment variables should not contain sensitive AWS values"
+  description = "Ensure authentication credentials AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY do not exist within AWS CodeBuild project environments. Do not store these variables in clear text. Storing these variables in clear text leads to unintended data exposure and unauthorized access."
+  query       = query.codebuild_project_plaintext_env_variables_no_sensitive_aws_values
 
   tags = merge(local.codebuild_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -35,9 +35,9 @@ control "codebuild_project_plaintext_env_variables_no_sensitive_aws_values" {
 }
 
 control "codebuild_project_source_repo_oauth_configured" {
-  title         = "CodeBuild GitHub or Bitbucket source repository URLs should use OAuth"
-  description   = "Ensure the GitHub or Bitbucket source repository URL does not contain personal access tokens, user name and password within AWS Codebuild project environments."
-  sql           = query.codebuild_project_source_repo_oauth_configured.sql
+  title       = "CodeBuild GitHub or Bitbucket source repository URLs should use OAuth"
+  description = "Ensure the GitHub or Bitbucket source repository URL does not contain personal access tokens, user name and password within AWS Codebuild project environments."
+  query       = query.codebuild_project_source_repo_oauth_configured
 
   tags = merge(local.codebuild_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -50,9 +50,9 @@ control "codebuild_project_source_repo_oauth_configured" {
 }
 
 control "codebuild_project_encryption_at_rest_enabled" {
-  title         = "CodeBuild project encryption at rest should be enabled"
-  description   = "Ensure CodeBuild projects are set to be encrypted at rest with customer-managed CMK to protect sensitive data."
-  sql           = query.codebuild_project_encryption_at_rest_enabled.sql
+  title       = "CodeBuild project encryption at rest should be enabled"
+  description = "Ensure CodeBuild projects are set to be encrypted at rest with customer-managed CMK to protect sensitive data."
+  query       = query.codebuild_project_encryption_at_rest_enabled
 
   tags = local.codebuild_compliance_common_tags
 }

--- a/controls/config.sp
+++ b/controls/config.sp
@@ -5,22 +5,22 @@ locals {
 }
 
 benchmark "config" {
-  title        = "Config"
-  description  = "This benchmark provides a set of controls that detect Terraform AWS Config resources deviating from security best practices."
+  title       = "Config"
+  description = "This benchmark provides a set of controls that detect Terraform AWS Config resources deviating from security best practices."
 
   children = [
     control.config_aggregator_enabled_all_regions
   ]
 
   tags = merge(local.config_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "config_aggregator_enabled_all_regions" {
-  title         = "Config aggregator should be enabled in all regions"
-  description   = "AWS Config should enable the config aggregator - allowing you to analyze the configuration across multiple accounts and regions."
-  sql           = query.config_aggregator_enabled_all_regions.sql
+  title       = "Config aggregator should be enabled in all regions"
+  description = "AWS Config should enable the config aggregator - allowing you to analyze the configuration across multiple accounts and regions."
+  query       = query.config_aggregator_enabled_all_regions
 
   tags = local.config_compliance_common_tags
 }

--- a/controls/dax.sp
+++ b/controls/dax.sp
@@ -5,22 +5,22 @@ locals {
 }
 
 benchmark "dax" {
-  title        = "DAX"
-  description  = "This benchmark provides a set of controls that detect Terraform AWS DAX resources deviating from security best practices."
+  title       = "DAX"
+  description = "This benchmark provides a set of controls that detect Terraform AWS DAX resources deviating from security best practices."
 
   children = [
     control.dax_cluster_encryption_at_rest_enabled
   ]
 
   tags = merge(local.dax_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "dax_cluster_encryption_at_rest_enabled" {
-  title         = "DynamoDB Accelerator (DAX) clusters should be encrypted at rest"
-  description   = "This control checks whether a DAX cluster is encrypted at rest. Encrypting data at rest reduces the risk of data stored on disk being accessed by a user not authenticated to AWS. The encryption adds another set of access controls to limit the ability of unauthorized users to access to the data. For example, API permissions are required to decrypt the data before it can be read."
-  sql           = query.dax_cluster_encryption_at_rest_enabled.sql
+  title       = "DynamoDB Accelerator (DAX) clusters should be encrypted at rest"
+  description = "This control checks whether a DAX cluster is encrypted at rest. Encrypting data at rest reduces the risk of data stored on disk being accessed by a user not authenticated to AWS. The encryption adds another set of access controls to limit the ability of unauthorized users to access to the data. For example, API permissions are required to decrypt the data before it can be read."
+  query       = query.dax_cluster_encryption_at_rest_enabled
 
   tags = merge(local.dax_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/dms.sp
+++ b/controls/dms.sp
@@ -13,14 +13,14 @@ benchmark "dms" {
   ]
 
   tags = merge(local.dms_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "dms_replication_instance_not_publicly_accessible" {
-  title         = "DMS replication instances should not be publicly accessible"
-  description   = "Manage access to the AWS Cloud by ensuring DMS replication instances cannot be publicly accessed."
-  sql           = query.dms_replication_instance_not_publicly_accessible.sql
+  title       = "DMS replication instances should not be publicly accessible"
+  description = "Manage access to the AWS Cloud by ensuring DMS replication instances cannot be publicly accessed."
+  query       = query.dms_replication_instance_not_publicly_accessible
 
   tags = merge(local.dms_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/docdb.sp
+++ b/controls/docdb.sp
@@ -14,22 +14,22 @@ benchmark "docdb" {
   ]
 
   tags = merge(local.docdb_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "docdb_cluster_audit_logs_enabled" {
-  title         = "DocDB cluster audit logging should be enabled"
-  description   = "Ensure DocDB cluster audit logging is enabled."
-  sql           = query.docdb_cluster_audit_logs_enabled.sql
+  title       = "DocDB cluster audit logging should be enabled"
+  description = "Ensure DocDB cluster audit logging is enabled."
+  query       = query.docdb_cluster_audit_logs_enabled
 
   tags = local.docdb_compliance_common_tags
 }
 
 control "docdb_cluster_encrypted_with_kms" {
-  title         = "DocDB cluster should be encrypted using KMS"
-  description   = "Ensure DocDB clusters being created are set to be encrypted at rest using customer-managed CMK."
-  sql           = query.docdb_cluster_encrypted_with_kms.sql
+  title       = "DocDB cluster should be encrypted using KMS"
+  description = "Ensure DocDB clusters being created are set to be encrypted at rest using customer-managed CMK."
+  query       = query.docdb_cluster_encrypted_with_kms
 
   tags = local.docdb_compliance_common_tags
 }

--- a/controls/dynamodb.sp
+++ b/controls/dynamodb.sp
@@ -16,14 +16,14 @@ benchmark "dynamodb" {
   ]
 
   tags = merge(local.dynamodb_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "dynamodb_table_encrypted_with_kms_cmk" {
-  title         = "DynamoDB table should be encrypted with AWS KMS"
-  description   = "Ensure that encryption is enabled for your Amazon DynamoDB tables. Because sensitive data can exist at rest in these tables, enable encryption at rest to help protect that data."
-  sql           = query.dynamodb_table_encrypted_with_kms_cmk.sql
+  title       = "DynamoDB table should be encrypted with AWS KMS"
+  description = "Ensure that encryption is enabled for your Amazon DynamoDB tables. Because sensitive data can exist at rest in these tables, enable encryption at rest to help protect that data."
+  query       = query.dynamodb_table_encrypted_with_kms_cmk
 
   tags = merge(local.dynamodb_compliance_common_tags, {
     gdpr               = "true"
@@ -34,9 +34,9 @@ control "dynamodb_table_encrypted_with_kms_cmk" {
 }
 
 control "dynamodb_table_encryption_enabled" {
-  title         = "DynamoDB table should have encryption enabled"
-  description   = "Ensure that encryption is enabled for your Amazon DynamoDB tables. Because sensitive data can exist at rest in these tables, enable encryption at rest to help protect that data."
-  sql           = query.dynamodb_table_encryption_enabled.sql
+  title       = "DynamoDB table should have encryption enabled"
+  description = "Ensure that encryption is enabled for your Amazon DynamoDB tables. Because sensitive data can exist at rest in these tables, enable encryption at rest to help protect that data."
+  query       = query.dynamodb_table_encryption_enabled
 
   tags = merge(local.dynamodb_compliance_common_tags, {
     gdpr  = "true"
@@ -45,9 +45,9 @@ control "dynamodb_table_encryption_enabled" {
 }
 
 control "dynamodb_table_point_in_time_recovery_enabled" {
-  title         = "DynamoDB table point-in-time recovery should be enabled"
-  description   = "Enable this rule to check that information has been backed up. It also maintains the backups by ensuring that point-in-time recovery is enabled in Amazon DynamoDB."
-  sql           = query.dynamodb_table_point_in_time_recovery_enabled.sql
+  title       = "DynamoDB table point-in-time recovery should be enabled"
+  description = "Enable this rule to check that information has been backed up. It also maintains the backups by ensuring that point-in-time recovery is enabled in Amazon DynamoDB."
+  query       = query.dynamodb_table_point_in_time_recovery_enabled
 
   tags = merge(local.dynamodb_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -60,9 +60,9 @@ control "dynamodb_table_point_in_time_recovery_enabled" {
 }
 
 control "dynamodb_vpc_endpoint_routetable_association" {
-  title         = "DynamoDB VPC endpoint should be enabled in all route tables in use in a VPC"
-  description   = "Using VPC endpoints helps to secure traffic by ensuring that the data does not traverse the internet or access public networks. It also helps keep private subnets private. Setting up VPC endpoints can be complicated."
-  sql           = query.dynamodb_vpc_endpoint_routetable_association.sql
+  title       = "DynamoDB VPC endpoint should be enabled in all route tables in use in a VPC"
+  description = "Using VPC endpoints helps to secure traffic by ensuring that the data does not traverse the internet or access public networks. It also helps keep private subnets private. Setting up VPC endpoints can be complicated."
+  query       = query.dynamodb_vpc_endpoint_routetable_association
 
   tags = local.dynamodb_compliance_common_tags
 }

--- a/controls/ebs.sp
+++ b/controls/ebs.sp
@@ -14,29 +14,29 @@ benchmark "ebs" {
   ]
 
   tags = merge(local.ebs_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "ebs_attached_volume_encryption_enabled" {
-  title         = "Attached EBS volumes should have encryption enabled"
-  description   = "Because sensitive data can exist and to help protect data at rest, ensure encryption is enabled for your Amazon Elastic Block Store (Amazon EBS) volumes."
-  sql           = query.ebs_attached_volume_encryption_enabled.sql
+  title       = "Attached EBS volumes should have encryption enabled"
+  description = "Because sensitive data can exist and to help protect data at rest, ensure encryption is enabled for your Amazon Elastic Block Store (Amazon EBS) volumes."
+  query       = query.ebs_attached_volume_encryption_enabled
 
   tags = merge(local.ebs_compliance_common_tags, {
-    aws_foundational_security   = "true"
-    gdpr                        = "true"
-    hipaa                       = "true"
-    nist_800_53_rev_4           = "true"
-    nist_csf                    = "true"
-    rbi_cyber_security          = "true"
+    aws_foundational_security = "true"
+    gdpr                      = "true"
+    hipaa                     = "true"
+    nist_800_53_rev_4         = "true"
+    nist_csf                  = "true"
+    rbi_cyber_security        = "true"
   })
 }
 
 control "ebs_volume_encryption_at_rest_enabled" {
-  title         = "EBS volumes should have encryption enabled"
-  description   = "Because sensitive data can exist and to help protect data at rest, ensure encryption is enabled for your Amazon Elastic Block Store (Amazon EBS) volumes."
-  sql           = query.ebs_attached_volume_encryption_enabled.sql
+  title       = "EBS volumes should have encryption enabled"
+  description = "Because sensitive data can exist and to help protect data at rest, ensure encryption is enabled for your Amazon Elastic Block Store (Amazon EBS) volumes."
+  query       = query.ebs_attached_volume_encryption_enabled
 
   tags = merge(local.ebs_compliance_common_tags, {
     cis                = "true"

--- a/controls/ec2.sp
+++ b/controls/ec2.sp
@@ -20,14 +20,14 @@ benchmark "ec2" {
   ]
 
   tags = merge(local.ec2_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "ec2_ebs_default_encryption_enabled" {
-  title         = "EBS default encryption should be enabled"
-  description   = "To help protect data at rest, ensure that encryption is enabled for your Amazon Elastic Block Store (Amazon EBS) volumes."
-  sql           = query.ec2_ebs_default_encryption_enabled.sql
+  title       = "EBS default encryption should be enabled"
+  description = "To help protect data at rest, ensure that encryption is enabled for your Amazon Elastic Block Store (Amazon EBS) volumes."
+  query       = query.ec2_ebs_default_encryption_enabled
 
   tags = merge(local.ec2_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -37,17 +37,17 @@ control "ec2_ebs_default_encryption_enabled" {
 }
 
 control "ec2_instance_not_use_default_vpc" {
-  title         = "Ensure EC2 instances do not use default VPC"
-  description   = "One of the best practices when using EC2s in AWS is not to deploy any resources to the default VPC."
-  sql           = query.ec2_instance_not_use_default_vpc.sql
+  title       = "Ensure EC2 instances do not use default VPC"
+  description = "One of the best practices when using EC2s in AWS is not to deploy any resources to the default VPC."
+  query       = query.ec2_instance_not_use_default_vpc
 
-  tags  = local.ec2_compliance_common_tags
+  tags = local.ec2_compliance_common_tags
 }
 
 control "ec2_instance_detailed_monitoring_enabled" {
-  title         = "EC2 instance detailed monitoring should be enabled"
-  description   = "Enable this rule to help improve Amazon Elastic Compute Cloud (Amazon EC2) instance monitoring on the Amazon EC2 console, which displays monitoring graphs with a one minute period for the instance."
-  sql           = query.ec2_instance_detailed_monitoring_enabled.sql
+  title       = "EC2 instance detailed monitoring should be enabled"
+  description = "Enable this rule to help improve Amazon Elastic Compute Cloud (Amazon EC2) instance monitoring on the Amazon EC2 console, which displays monitoring graphs with a one minute period for the instance."
+  query       = query.ec2_instance_detailed_monitoring_enabled
 
   tags = merge(local.ec2_compliance_common_tags, {
     nist_800_53_rev_4 = "true"
@@ -57,21 +57,21 @@ control "ec2_instance_detailed_monitoring_enabled" {
 }
 
 control "ec2_instance_ebs_optimized" {
-  title         = "EC2 instance should have EBS optimization enabled"
-  description   = "An optimized instance in Amazon Elastic Block Store (Amazon EBS) provides additional, dedicated capacity for Amazon EBS I/O operations."
-  sql           = query.ec2_instance_ebs_optimized.sql
+  title       = "EC2 instance should have EBS optimization enabled"
+  description = "An optimized instance in Amazon Elastic Block Store (Amazon EBS) provides additional, dedicated capacity for Amazon EBS I/O operations."
+  query       = query.ec2_instance_ebs_optimized
 
   tags = merge(local.ec2_compliance_common_tags, {
-    hipaa                       = "true"
-    nist_csf                    = "true"
-    soc_2                       = "true"
+    hipaa    = "true"
+    nist_csf = "true"
+    soc_2    = "true"
   })
 }
 
 control "ec2_instance_not_publicly_accessible" {
-  title         = "EC2 instances should not have a public IP address"
-  description   = "Manage access to the AWS Cloud by ensuring Amazon Elastic Compute Cloud (Amazon EC2) instances cannot be publicly accessed."
-  sql           = query.ec2_instance_not_publicly_accessible.sql
+  title       = "EC2 instances should not have a public IP address"
+  description = "Manage access to the AWS Cloud by ensuring Amazon Elastic Compute Cloud (Amazon EC2) instances cannot be publicly accessed."
+  query       = query.ec2_instance_not_publicly_accessible
 
   tags = merge(local.ec2_compliance_common_tags, {
     hipaa              = "true"
@@ -83,9 +83,9 @@ control "ec2_instance_not_publicly_accessible" {
 }
 
 control "ec2_instance_not_use_multiple_enis" {
-  title         = "EC2 instances should not use multiple ENIs"
-  description   = "This control checks whether an EC2 instance uses multiple Elastic Network Interfaces (ENIs) or Elastic Fabric Adapters (EFAs). This control passes if a single network adapter is used. The control includes an optional parameter list to identify the allowed ENIs."
-  sql           = query.ec2_instance_not_use_multiple_enis.sql
+  title       = "EC2 instances should not use multiple ENIs"
+  description = "This control checks whether an EC2 instance uses multiple Elastic Network Interfaces (ENIs) or Elastic Fabric Adapters (EFAs). This control passes if a single network adapter is used. The control includes an optional parameter list to identify the allowed ENIs."
+  query       = query.ec2_instance_not_use_multiple_enis
 
   tags = merge(local.ec2_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -93,17 +93,17 @@ control "ec2_instance_not_use_multiple_enis" {
 }
 
 control "ec2_instance_termination_protection_enabled" {
-  title         = "EC2 instances termination protection should be enabled"
-  description   = "To prevent your instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance."
-  sql           = query.ec2_instance_termination_protection_enabled.sql
+  title       = "EC2 instances termination protection should be enabled"
+  description = "To prevent your instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance."
+  query       = query.ec2_instance_termination_protection_enabled
 
   tags = local.ec2_compliance_common_tags
 }
 
 control "ec2_instance_uses_imdsv2" {
-  title         = "EC2 instances should use IMDSv2"
-  description   = "Ensure the Instance Metadata Service Version 2 (IMDSv2) method is enabled to help protect access and control of Amazon Elastic Compute Cloud (Amazon EC2) instance metadata."
-  sql           = query.ec2_instance_uses_imdsv2.sql
+  title       = "EC2 instances should use IMDSv2"
+  description = "Ensure the Instance Metadata Service Version 2 (IMDSv2) method is enabled to help protect access and control of Amazon Elastic Compute Cloud (Amazon EC2) instance metadata."
+  query       = query.ec2_instance_uses_imdsv2
 
   tags = merge(local.ec2_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/ecr.sp
+++ b/controls/ecr.sp
@@ -18,27 +18,27 @@ benchmark "ecr" {
 }
 
 control "ecr_repository_tags_immutable" {
-  title         = "ECR repository tags should be immutable"
-  description   = "AWS ECR should have all tags be immutable - once a container is published, another image cannot assume the same tag."
-  sql           = query.ecr_repository_tags_immutable.sql
+  title       = "ECR repository tags should be immutable"
+  description = "AWS ECR should have all tags be immutable - once a container is published, another image cannot assume the same tag."
+  query       = query.ecr_repository_tags_immutable
 
   tags = merge(local.ecr_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "ecr_repository_use_image_scanning" {
-  title         = "ECR repository should use image scanning"
-  description   = "One of the best practices when making containers available through AWS ECR is to scan them for vulnerabilities before sharing or using them."
-  sql           = query.ecr_repository_use_image_scanning.sql
+  title       = "ECR repository should use image scanning"
+  description = "One of the best practices when making containers available through AWS ECR is to scan them for vulnerabilities before sharing or using them."
+  query       = query.ecr_repository_use_image_scanning
 
-   tags     = local.ecr_compliance_common_tags
+  tags = local.ecr_compliance_common_tags
 }
 
 control "ecr_repository_encrypted_with_kms" {
-  title         = "ECR repository should be encrypted with KMS"
-  description   = "Ensure ECR repositories being created are set to be encrypted at rest using customer-managed CMK."
-  sql           = query.ecr_repository_encrypted_with_kms.sql
+  title       = "ECR repository should be encrypted with KMS"
+  description = "Ensure ECR repositories being created are set to be encrypted at rest using customer-managed CMK."
+  query       = query.ecr_repository_encrypted_with_kms
 
-   tags     = local.ecr_compliance_common_tags
+  tags = local.ecr_compliance_common_tags
 }

--- a/controls/ecs.sp
+++ b/controls/ecs.sp
@@ -14,22 +14,22 @@ benchmark "ecs" {
   ]
 
   tags = merge(local.ecs_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "ecs_cluster_container_insights_enabled" {
-  title         = "ECS cluster container insights should be enabled"
-  description   = "One of the best practices when using AWS ECS is to enable cluster container insights for better visibility."
-  sql           = query.ecs_cluster_container_insights_enabled.sql
+  title       = "ECS cluster container insights should be enabled"
+  description = "One of the best practices when using AWS ECS is to enable cluster container insights for better visibility."
+  query       = query.ecs_cluster_container_insights_enabled
 
   tags = local.ecs_compliance_common_tags
 }
 
 control "ecs_task_definition_encryption_in_transit_enabled" {
-  title         = "ECS task definition encryption in transit should be enabled"
-  description   = "Ensure encryption in transit is enabled for EFS volumes in ECS Task definitions."
-  sql           = query.ecs_task_definition_encryption_in_transit_enabled.sql
+  title       = "ECS task definition encryption in transit should be enabled"
+  description = "Ensure encryption in transit is enabled for EFS volumes in ECS Task definitions."
+  query       = query.ecs_task_definition_encryption_in_transit_enabled
 
   tags = local.ecs_compliance_common_tags
 }

--- a/controls/efs.sp
+++ b/controls/efs.sp
@@ -14,14 +14,14 @@ benchmark "efs" {
   ]
 
   tags = merge(local.efs_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "efs_file_system_automatic_backups_enabled" {
-  title         = "EFS file systems should be in a backup plan"
-  description   = "To help with data back-up processes, ensure your Amazon Elastic File System (Amazon EFS) file systems are a part of an AWS Backup plan."
-  sql           = query.efs_file_system_automatic_backups_enabled.sql
+  title       = "EFS file systems should be in a backup plan"
+  description = "To help with data back-up processes, ensure your Amazon Elastic File System (Amazon EFS) file systems are a part of an AWS Backup plan."
+  query       = query.efs_file_system_automatic_backups_enabled
 
   tags = merge(local.efs_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -34,9 +34,9 @@ control "efs_file_system_automatic_backups_enabled" {
 }
 
 control "efs_file_system_encrypt_data_at_rest" {
-  title         = "EFS file system encryption at rest should be enabled"
-  description   = "Because sensitive data can exist and to help protect data at rest, ensure encryption is enabled for your Amazon Elastic File System (EFS)."
-  sql           = query.efs_file_system_encrypt_data_at_rest.sql
+  title       = "EFS file system encryption at rest should be enabled"
+  description = "Because sensitive data can exist and to help protect data at rest, ensure encryption is enabled for your Amazon Elastic File System (EFS)."
+  query       = query.efs_file_system_encrypt_data_at_rest
 
   tags = merge(local.efs_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/eks.sp
+++ b/controls/eks.sp
@@ -15,14 +15,14 @@ benchmark "eks" {
   ]
 
   tags = merge(local.eks_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "eks_cluster_endpoint_restrict_public_access" {
-  title         = "EKS clusters endpoint should restrict public access"
-  description   = "Ensure whether Amazon Elastic Kubernetes Service (Amazon EKS) endpoint is not publicly accessible. The rule is complaint if the endpoint is publicly accessible."
-  sql           = query.eks_cluster_endpoint_restrict_public_access.sql
+  title       = "EKS clusters endpoint should restrict public access"
+  description = "Ensure whether Amazon Elastic Kubernetes Service (Amazon EKS) endpoint is not publicly accessible. The rule is complaint if the endpoint is publicly accessible."
+  query       = query.eks_cluster_endpoint_restrict_public_access
 
   tags = merge(local.eks_compliance_common_tags, {
     nist_csf = "true"
@@ -30,17 +30,17 @@ control "eks_cluster_endpoint_restrict_public_access" {
 }
 
 control "eks_cluster_log_types_enabled" {
-  title         = "EKS cluster log types should be enabled"
-  description   = "Ensure Amazon EKS cluster logging is enabled for all log types"
-  sql           = query.eks_cluster_log_types_enabled.sql
+  title       = "EKS cluster log types should be enabled"
+  description = "Ensure Amazon EKS cluster logging is enabled for all log types"
+  query       = query.eks_cluster_log_types_enabled
 
   tags = local.eks_compliance_common_tags
 }
 
 control "eks_cluster_secrets_encrypted" {
-  title         = "EKS clusters should be configured to have kubernetes secrets encrypted using KMS"
-  description   = "Ensure if Amazon Elastic Kubernetes Service clusters are configured to have Kubernetes secrets encrypted using AWS Key Management Service (KMS) keys."
-  sql           = query.eks_cluster_secrets_encrypted.sql
+  title       = "EKS clusters should be configured to have kubernetes secrets encrypted using KMS"
+  description = "Ensure if Amazon Elastic Kubernetes Service clusters are configured to have Kubernetes secrets encrypted using AWS Key Management Service (KMS) keys."
+  query       = query.eks_cluster_secrets_encrypted
 
   tags = merge(local.eks_compliance_common_tags, {
     hipaa = "true"

--- a/controls/elasticache.sp
+++ b/controls/elasticache.sp
@@ -14,14 +14,14 @@ benchmark "elasticache" {
   ]
 
   tags = merge(local.elasticache_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "elasticache_redis_cluster_automatic_backup_retention_15_days" {
-  title         = "ElastiCache Redis cluster automatic backup should be enabled with retention period of 15 days or greater"
-  description   = "When automatic backups are enabled, Amazon ElastiCache creates a backup of the cluster on a daily basis. The backup can be retained for a number of days as specified by your organization. Automatic backups can help guard against data loss."
-  sql           = query.elasticache_redis_cluster_automatic_backup_retention_15_days.sql
+  title       = "ElastiCache Redis cluster automatic backup should be enabled with retention period of 15 days or greater"
+  description = "When automatic backups are enabled, Amazon ElastiCache creates a backup of the cluster on a daily basis. The backup can be retained for a number of days as specified by your organization. Automatic backups can help guard against data loss."
+  query       = query.elasticache_redis_cluster_automatic_backup_retention_15_days
 
   tags = merge(local.elasticache_compliance_common_tags, {
     hipaa              = "true"
@@ -33,9 +33,9 @@ control "elasticache_redis_cluster_automatic_backup_retention_15_days" {
 }
 
 control "elasticache_replication_group_encryption_in_transit_enabled" {
-  title         = "ElastiCache replication group should be encrypted at transit"
-  description   = "Ensure all data stored in the Elasticache Replication Group is securely encrypted at transit"
-  sql           = query.elasticache_replication_group_encryption_in_transit_enabled.sql
+  title       = "ElastiCache replication group should be encrypted at transit"
+  description = "Ensure all data stored in the Elasticache Replication Group is securely encrypted at transit"
+  query       = query.elasticache_replication_group_encryption_in_transit_enabled
 
   tags = local.elasticache_compliance_common_tags
 }

--- a/controls/elb.sp
+++ b/controls/elb.sp
@@ -20,14 +20,14 @@ benchmark "elb" {
   ]
 
   tags = merge(local.elb_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "ec2_classic_lb_connection_draining_enabled" {
-  title         = "Classic Load Balancers should have connection draining enabled"
-  description   = "This control checks whether Classic Load Balancers have connection draining enabled."
-  sql           = query.ec2_classic_lb_connection_draining_enabled.sql
+  title       = "Classic Load Balancers should have connection draining enabled"
+  description = "This control checks whether Classic Load Balancers have connection draining enabled."
+  query       = query.ec2_classic_lb_connection_draining_enabled
 
   tags = merge(local.elb_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -35,51 +35,51 @@ control "ec2_classic_lb_connection_draining_enabled" {
 }
 
 control "elb_application_classic_lb_logging_enabled" {
-  title         = "ELB application and classic load balancer logging should be enabled"
-  description   = "Elastic Load Balancing activity is a central point of communication within an environment. Ensure that logging is enabled to track the activities of the load balancer."
-  sql           = query.elb_application_classic_lb_logging_enabled.sql
+  title       = "ELB application and classic load balancer logging should be enabled"
+  description = "Elastic Load Balancing activity is a central point of communication within an environment. Ensure that logging is enabled to track the activities of the load balancer."
+  query       = query.elb_application_classic_lb_logging_enabled
 
   tags = merge(local.elb_compliance_common_tags, {
     aws_foundational_security = "true"
-    gdpr               = "true"
-    hipaa              = "true"
-    nist_800_53_rev_4  = "true"
-    nist_csf           = "true"
-    rbi_cyber_security = "true"
-    soc_2              = "true"
+    gdpr                      = "true"
+    hipaa                     = "true"
+    nist_800_53_rev_4         = "true"
+    nist_csf                  = "true"
+    rbi_cyber_security        = "true"
+    soc_2                     = "true"
   })
 }
 
 control "elb_application_lb_deletion_protection_enabled" {
-  title         = "ELB application load balancer deletion protection should be enabled"
-  description   = "This rule ensures that Elastic Load Balancing has deletion protection enabled."
-  sql           = query.elb_application_lb_deletion_protection_enabled.sql
+  title       = "ELB application load balancer deletion protection should be enabled"
+  description = "This rule ensures that Elastic Load Balancing has deletion protection enabled."
+  query       = query.elb_application_lb_deletion_protection_enabled
 
   tags = merge(local.elb_compliance_common_tags, {
     aws_foundational_security = "true"
-    hipaa    = "true"
-    nist_csf = "true"
+    hipaa                     = "true"
+    nist_csf                  = "true"
   })
 }
 
 control "elb_application_lb_drop_http_headers" {
-  title         = "ELB application load balancers should be drop HTTP headers"
-  description   = "Ensure that your Elastic Load Balancers (ELB) are configured to drop http headers."
-  sql           = query.elb_application_lb_drop_http_headers.sql
+  title       = "ELB application load balancers should be drop HTTP headers"
+  description = "Ensure that your Elastic Load Balancers (ELB) are configured to drop http headers."
+  query       = query.elb_application_lb_drop_http_headers
 
   tags = merge(local.elb_compliance_common_tags, {
     aws_foundational_security = "true"
-    hipaa              = "true"
-    gdpr               = "true"
-    nist_800_53_rev_4  = "true"
-    rbi_cyber_security = "true"
+    hipaa                     = "true"
+    gdpr                      = "true"
+    nist_800_53_rev_4         = "true"
+    rbi_cyber_security        = "true"
   })
 }
 
 control "elb_application_lb_waf_enabled" {
-  title         = "ELB application load balancers should have Web Application Firewall (WAF) enabled"
-  description   = "Ensure AWS WAF is enabled on Elastic Load Balancers (ELB) to help protect web applications."
-  sql           = query.elb_application_lb_waf_enabled.sql
+  title       = "ELB application load balancers should have Web Application Firewall (WAF) enabled"
+  description = "Ensure AWS WAF is enabled on Elastic Load Balancers (ELB) to help protect web applications."
+  query       = query.elb_application_lb_waf_enabled
 
   tags = merge(local.elb_compliance_common_tags, {
     nist_800_53_rev_4  = "true"
@@ -89,9 +89,9 @@ control "elb_application_lb_waf_enabled" {
 }
 
 control "elb_classic_lb_cross_zone_load_balancing_enabled" {
-  title         = "ELB classic load balancers should have cross-zone load balancing enabled"
-  description   = "Enable cross-zone load balancing for your Elastic Load Balancers (ELBs) to help maintain adequate capacity and availability. The cross-zone load balancing reduces the need to maintain equivalent number of instances in each enabled availability zone."
-  sql           = query.elb_classic_lb_cross_zone_load_balancing_enabled.sql
+  title       = "ELB classic load balancers should have cross-zone load balancing enabled"
+  description = "Enable cross-zone load balancing for your Elastic Load Balancers (ELBs) to help maintain adequate capacity and availability. The cross-zone load balancing reduces the need to maintain equivalent number of instances in each enabled availability zone."
+  query       = query.elb_classic_lb_cross_zone_load_balancing_enabled
 
   tags = merge(local.elb_compliance_common_tags, {
     nist_800_53_rev_4 = "true"
@@ -100,9 +100,9 @@ control "elb_classic_lb_cross_zone_load_balancing_enabled" {
 }
 
 control "elb_classic_lb_use_ssl_certificate" {
-  title         = "ELB classic load balancers should use SSL certificates"
-  description   = "Because sensitive data can exist and to help protect data at transit, ensure encryption is enabled for your Elastic Load Balancing."
-  sql           = query.elb_classic_lb_use_ssl_certificate.sql
+  title       = "ELB classic load balancers should use SSL certificates"
+  description = "Because sensitive data can exist and to help protect data at transit, ensure encryption is enabled for your Elastic Load Balancing."
+  query       = query.elb_classic_lb_use_ssl_certificate
 
   tags = merge(local.elb_compliance_common_tags, {
     gdpr               = "true"
@@ -114,9 +114,9 @@ control "elb_classic_lb_use_ssl_certificate" {
 }
 
 control "elb_classic_lb_use_tls_https_listeners" {
-  title         = "ELB classic load balancers should only use SSL or HTTPS listeners"
-  description   = "Ensure that your Elastic Load Balancers (ELBs) are configured with SSL or HTTPS listeners. Because sensitive data can exist, enable encryption in transit to help protect that data."
-  sql           = query.elb_classic_lb_use_tls_https_listeners.sql
+  title       = "ELB classic load balancers should only use SSL or HTTPS listeners"
+  description = "Ensure that your Elastic Load Balancers (ELBs) are configured with SSL or HTTPS listeners. Because sensitive data can exist, enable encryption in transit to help protect that data."
+  query       = query.elb_classic_lb_use_tls_https_listeners
 
   tags = merge(local.elb_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/emr.sp
+++ b/controls/emr.sp
@@ -13,14 +13,14 @@ benchmark "emr" {
   ]
 
   tags = merge(local.emr_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "emr_cluster_kerberos_enabled" {
-  title         = "EMR cluster Kerberos should be enabled"
-  description   = "The access permissions and authorizations can be managed and incorporated with the principles of least privilege and separation of duties, by enabling Kerberos for Amazon EMR clusters."
-  sql           = query.emr_cluster_kerberos_enabled.sql
+  title       = "EMR cluster Kerberos should be enabled"
+  description = "The access permissions and authorizations can be managed and incorporated with the principles of least privilege and separation of duties, by enabling Kerberos for Amazon EMR clusters."
+  query       = query.emr_cluster_kerberos_enabled
 
   tags = merge(local.emr_compliance_common_tags, {
     hipaa             = "true"

--- a/controls/es.sp
+++ b/controls/es.sp
@@ -21,14 +21,14 @@ benchmark "es" {
   ]
 
   tags = merge(local.es_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "es_domain_audit_logging_enabled" {
-  title         = "Elasticsearch domains should have audit logging enabled"
-  description   = "This control checks whether Elasticsearch domains have audit logging enabled. This control fails if an Elasticsearch domain does not have audit logging enabled."
-  sql           = query.es_domain_audit_logging_enabled.sql
+  title       = "Elasticsearch domains should have audit logging enabled"
+  description = "This control checks whether Elasticsearch domains have audit logging enabled. This control fails if an Elasticsearch domain does not have audit logging enabled."
+  query       = query.es_domain_audit_logging_enabled
 
   tags = merge(local.es_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -36,9 +36,9 @@ control "es_domain_audit_logging_enabled" {
 }
 
 control "es_domain_data_nodes_min_3" {
-  title         = "Elasticsearch domains should have at least three data nodes"
-  description   = "This control checks whether Elasticsearch domains are configured with at least three data nodes and zoneAwarenessEnabled is set to true."
-  sql           = query.es_domain_data_nodes_min_3.sql
+  title       = "Elasticsearch domains should have at least three data nodes"
+  description = "This control checks whether Elasticsearch domains are configured with at least three data nodes and zoneAwarenessEnabled is set to true."
+  query       = query.es_domain_data_nodes_min_3
 
   tags = merge(local.es_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -46,9 +46,9 @@ control "es_domain_data_nodes_min_3" {
 }
 
 control "es_domain_dedicated_master_nodes_min_3" {
-  title         = "Elasticsearch domains should be configured with at least three dedicated master nodes"
-  description   = "This control checks whether Elasticsearch domains are configured with at least three dedicated master nodes. This control fails if the domain does not use dedicated master nodes. This control passes if Elasticsearch domains have five dedicated master nodes. However, using more than three master nodes might be unnecessary to mitigate the availability risk, and will result in additional cost."
-  sql           = query.es_domain_dedicated_master_nodes_min_3.sql
+  title       = "Elasticsearch domains should be configured with at least three dedicated master nodes"
+  description = "This control checks whether Elasticsearch domains are configured with at least three dedicated master nodes. This control fails if the domain does not use dedicated master nodes. This control passes if Elasticsearch domains have five dedicated master nodes. However, using more than three master nodes might be unnecessary to mitigate the availability risk, and will result in additional cost."
+  query       = query.es_domain_dedicated_master_nodes_min_3
 
   tags = merge(local.es_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -56,9 +56,9 @@ control "es_domain_dedicated_master_nodes_min_3" {
 }
 
 control "es_domain_encrypted_using_tls_1_2" {
-  title         = "Connections to Elasticsearch domains should be encrypted using TLS 1.2"
-  description   = "This control checks whether connections to Elasticsearch domains are required to use TLS 1.2. The check fails if the Elasticsearch domain TLSSecurityPolicy is not Policy-Min-TLS-1-2-2019-07."
-  sql           = query.es_domain_encrypted_using_tls_1_2.sql
+  title       = "Connections to Elasticsearch domains should be encrypted using TLS 1.2"
+  description = "This control checks whether connections to Elasticsearch domains are required to use TLS 1.2. The check fails if the Elasticsearch domain TLSSecurityPolicy is not Policy-Min-TLS-1-2-2019-07."
+  query       = query.es_domain_encrypted_using_tls_1_2
 
   tags = merge(local.es_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -66,9 +66,9 @@ control "es_domain_encrypted_using_tls_1_2" {
 }
 
 control "es_domain_encryption_at_rest_enabled" {
-  title         = "ES domain encryption at rest should be enabled"
-  description   = "Because sensitive data can exist and to help protect data at rest, ensure encryption is enabled for your Amazon Elasticsearch Service (Amazon ES) domains."
-  sql           = query.es_domain_encryption_at_rest_enabled.sql
+  title       = "ES domain encryption at rest should be enabled"
+  description = "Because sensitive data can exist and to help protect data at rest, ensure encryption is enabled for your Amazon Elasticsearch Service (Amazon ES) domains."
+  query       = query.es_domain_encryption_at_rest_enabled
   tags = merge(local.es_compliance_common_tags, {
     aws_foundational_security = "true"
     gdpr                      = "true"
@@ -81,9 +81,9 @@ control "es_domain_encryption_at_rest_enabled" {
 }
 
 control "es_domain_error_logging_enabled" {
-  title         = "Elasticsearch domain error logging to CloudWatch Logs should be enabled"
-  description   = "This control checks whether Elasticsearch domains are configured to send error logs to CloudWatch Logs."
-  sql           = query.es_domain_error_logging_enabled.sql
+  title       = "Elasticsearch domain error logging to CloudWatch Logs should be enabled"
+  description = "This control checks whether Elasticsearch domains are configured to send error logs to CloudWatch Logs."
+  query       = query.es_domain_error_logging_enabled
 
   tags = merge(local.es_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -91,9 +91,9 @@ control "es_domain_error_logging_enabled" {
 }
 
 control "es_domain_in_vpc" {
-  title         = "Amazon Elasticsearch Service domains should be in a VPC"
-  description   = "This control checks whether Amazon Elasticsearch Service domains are in a VPC. It does not evaluate the VPC subnet routing configuration to determine public access. You should ensure that Amazon Elasticsearch domains are not attached to public subnets."
-  sql           = query.es_domain_in_vpc.sql
+  title       = "Amazon Elasticsearch Service domains should be in a VPC"
+  description = "This control checks whether Amazon Elasticsearch Service domains are in a VPC. It does not evaluate the VPC subnet routing configuration to determine public access. You should ensure that Amazon Elasticsearch domains are not attached to public subnets."
+  query       = query.es_domain_in_vpc
 
   tags = merge(local.es_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -108,7 +108,7 @@ control "es_domain_in_vpc" {
 control "es_domain_logs_to_cloudwatch" {
   title       = "Elasticsearch domain should send logs to cloudWatch"
   description = "Ensure if Amazon OpenSearch Service (OpenSearch Service) domains are configured to send logs to Amazon CloudWatch Logs. The rule is complaint if a log is enabled for an OpenSearch Service domain. This rule is non complain if logging is not configured."
-  sql           = query.es_domain_logs_to_cloudwatch.sql
+  query       = query.es_domain_logs_to_cloudwatch
 
   tags = merge(local.es_compliance_common_tags, {
     rbi_cyber_security = "true"
@@ -118,7 +118,7 @@ control "es_domain_logs_to_cloudwatch" {
 control "es_domain_node_to_node_encryption_enabled" {
   title       = "Elasticsearch domain node-to-node encryption should be enabled"
   description = "Ensure node-to-node encryption for Amazon Elasticsearch Service is enabled. Node-to-node encryption enables TLS 1.2 encryption for all communications within the Amazon Virtual Private Cloud (Amazon VPC)."
-  sql           = query.es_domain_node_to_node_encryption_enabled.sql
+  query       = query.es_domain_node_to_node_encryption_enabled
 
   tags = merge(local.es_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/globalaccelerator.sp
+++ b/controls/globalaccelerator.sp
@@ -13,14 +13,14 @@ benchmark "globalaccelerator" {
   ]
 
   tags = merge(local.globalaccelerator_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "globalaccelerator_flow_logs_enabled" {
-  title         = "Global Accelerator  flow logs should be enabled"
-  description   = "Ensure Global Accelerator accelerator has flow logs enabled"
-  sql           = query.globalaccelerator_flow_logs_enabled.sql
+  title       = "Global Accelerator  flow logs should be enabled"
+  description = "Ensure Global Accelerator accelerator has flow logs enabled"
+  query       = query.globalaccelerator_flow_logs_enabled
 
   tags = local.globalaccelerator_compliance_common_tags
 }

--- a/controls/guardduty.sp
+++ b/controls/guardduty.sp
@@ -13,14 +13,14 @@ benchmark "guardduty" {
   ]
 
   tags = merge(local.guardduty_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "guardduty_enabled" {
   title       = "GuardDuty should be enabled"
   description = "Amazon GuardDuty can help to monitor and detect potential cybersecurity events by using threat intelligence feeds."
-  sql           = query.guardduty_enabled.sql
+  query       = query.guardduty_enabled
 
   tags = merge(local.guardduty_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/iam.sp
+++ b/controls/iam.sp
@@ -21,14 +21,14 @@ benchmark "iam" {
   ]
 
   tags = merge(local.iam_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "iam_account_password_policy_min_length_14" {
   title       = "Ensure IAM password policy requires minimum length of 14 or greate"
   description = "Password policies are, in part, used to enforce password complexity requirements. IAM password policies can be used to ensure password are at least a given length. It is recommended that the password policy require a minimum password length 14."
-  sql           = query.iam_account_password_policy_min_length_14.sql
+  query       = query.iam_account_password_policy_min_length_14
 
   tags = merge(local.iam_compliance_common_tags, {
     cis   = "true"
@@ -40,7 +40,7 @@ control "iam_account_password_policy_min_length_14" {
 control "iam_account_password_policy_one_lowercase_letter" {
   title       = "Ensure IAM password policy requires at least one lowercase letter"
   description = "Password policies, in part, enforce password complexity requirements. Use IAM password policies to ensure that passwords use different character sets. Security Hub recommends that the password policy require at least one lowercase letter. Setting a password complexity policy increases account resiliency against brute force login attempts."
-  sql           = query.iam_account_password_policy_one_lowercase_letter.sql
+  query       = query.iam_account_password_policy_one_lowercase_letter
 
   tags = merge(local.iam_compliance_common_tags, {
     gdpr  = "true"
@@ -51,7 +51,7 @@ control "iam_account_password_policy_one_lowercase_letter" {
 control "iam_account_password_policy_one_number" {
   title       = "Ensure IAM password policy requires at least one number"
   description = "Password policies, in part, enforce password complexity requirements. Use IAM password policies to ensure that passwords use different character sets."
-  sql           = query.iam_account_password_policy_one_number.sql
+  query       = query.iam_account_password_policy_one_number
 
   tags = merge(local.iam_compliance_common_tags, {
     gdpr  = "true"
@@ -62,7 +62,7 @@ control "iam_account_password_policy_one_number" {
 control "iam_account_password_policy_one_symbol" {
   title       = "Ensure IAM password policy requires at least one symbol"
   description = "Password policies, in part, enforce password complexity requirements. Use IAM password policies to ensure that passwords use different character sets. Security Hub recommends that the password policy require at least one symbol. Setting a password complexity policy increases account resiliency against brute force login attempts."
-  sql           = query.iam_account_password_policy_one_symbol.sql
+  query       = query.iam_account_password_policy_one_symbol
 
   tags = merge(local.iam_compliance_common_tags, {
     gdpr  = "true"
@@ -73,7 +73,7 @@ control "iam_account_password_policy_one_symbol" {
 control "iam_account_password_policy_one_uppercase_letter" {
   title       = "Ensure IAM password policy requires at least one uppercase letter"
   description = "Password policies, in part, enforce password complexity requirements. Use IAM password policies to ensure that passwords use different character sets."
-  sql           = query.iam_account_password_policy_one_uppercase_letter.sql
+  query       = query.iam_account_password_policy_one_uppercase_letter
 
   tags = merge(local.iam_compliance_common_tags, {
     gdpr  = "true"
@@ -84,20 +84,20 @@ control "iam_account_password_policy_one_uppercase_letter" {
 control "iam_account_password_policy_reuse_24" {
   title       = "Ensure IAM password policy prevents password reuse"
   description = "This control checks whether the number of passwords to remember is set to 24. The control fails if the value is not 24. IAM password policies can prevent the reuse of a given password by the same user."
-  sql           = query.iam_account_password_policy_reuse_24.sql
+  query       = query.iam_account_password_policy_reuse_24
 
   tags = merge(local.iam_compliance_common_tags, {
-    cis = "true"
+    cis   = "true"
     gdpr  = "true"
     hipaa = "true"
   })
 }
 
 control "iam_account_password_policy_strong_min_length_8" {
-  title         = "Ensure IAM password policy requires a minimum length of 8 or greater"
-  description   = "This control checks whether the account password policy for IAM users uses the recommended configurations."
-  severity      = "medium"
-  sql           = query.iam_account_password_policy_strong_min_length_8.sql
+  title       = "Ensure IAM password policy requires a minimum length of 8 or greater"
+  description = "This control checks whether the account password policy for IAM users uses the recommended configurations."
+  severity    = "medium"
+  query       = query.iam_account_password_policy_strong_min_length_8
 
   tags = merge(local.iam_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -107,7 +107,7 @@ control "iam_account_password_policy_strong_min_length_8" {
 control "iam_account_password_policy_strong" {
   title       = "Password policies for IAM users should have strong configurations"
   description = "This control checks whether the account password policy for IAM users have strong configurations."
-  sql           = query.iam_account_password_policy_strong.sql
+  query       = query.iam_account_password_policy_strong
 
   tags = merge(local.iam_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -121,7 +121,7 @@ control "iam_account_password_policy_strong" {
 control "iam_password_policy_expire_90" {
   title       = "Ensure IAM password policy expires passwords within 90 days or less"
   description = "IAM password policies can require passwords to be rotated or expired after a given number of days. Security Hub recommends that the password policy expire passwords after 90 days or less. Reducing the password lifetime increases account resiliency against brute force login attempts."
-  sql           = query.iam_password_policy_expire_90.sql
+  query       = query.iam_password_policy_expire_90
 
   tags = merge(local.iam_compliance_common_tags, {
     gdpr  = "true"

--- a/controls/kinesis.sp
+++ b/controls/kinesis.sp
@@ -13,14 +13,14 @@ benchmark "kinesis" {
   ]
 
   tags = merge(local.kinesis_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "kinesis_stream_encryption_at_rest_enabled" {
-  title         = "Kinesis stream encryption at rest should be enabled"
-  description   = "Ensure Kinesis streams are set to be encrypted at rest to protect sensitive data."
-  sql           = query.kinesis_stream_encryption_at_rest_enabled.sql
+  title       = "Kinesis stream encryption at rest should be enabled"
+  description = "Ensure Kinesis streams are set to be encrypted at rest to protect sensitive data."
+  query       = query.kinesis_stream_encryption_at_rest_enabled
 
   tags = local.kinesis_compliance_common_tags
 }

--- a/controls/kms.sp
+++ b/controls/kms.sp
@@ -13,14 +13,14 @@ benchmark "kms" {
   ]
 
   tags = merge(local.kms_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "kms_cmk_rotation_enabled" {
   title       = "KMS CMK rotation should be enabled"
   description = "Enable key rotation to ensure that keys are rotated once they have reached the end of their crypto period."
-  sql           = query.kms_cmk_rotation_enabled.sql
+  query       = query.kms_cmk_rotation_enabled
 
   tags = merge(local.kms_compliance_common_tags, {
     cis                = "true"

--- a/controls/lambda.sp
+++ b/controls/lambda.sp
@@ -17,14 +17,14 @@ benchmark "lambda" {
   ]
 
   tags = merge(local.lambda_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "lambda_function_concurrent_execution_limit_configured" {
   title       = "Lambda functions concurrent execution limit configured"
   description = "Checks whether the AWS Lambda function is configured with function-level concurrent execution limit. The control is non complaint if the Lambda function is not configured with function-level concurrent execution limit."
-  sql           = query.lambda_function_concurrent_execution_limit_configured.sql
+  query       = query.lambda_function_concurrent_execution_limit_configured
 
   tags = merge(local.lambda_compliance_common_tags, {
     nist_csf = "true"
@@ -35,7 +35,7 @@ control "lambda_function_concurrent_execution_limit_configured" {
 control "lambda_function_dead_letter_queue_configured" {
   title       = "Lambda functions should be configured with a dead-letter queue"
   description = "Enable this rule to help notify the appropriate personnel through Amazon Simple Queue Service (Amazon SQS) or Amazon Simple Notification Service (Amazon SNS) when a function has failed."
-  sql           = query.lambda_function_dead_letter_queue_configured.sql
+  query       = query.lambda_function_dead_letter_queue_configured
 
   tags = merge(local.lambda_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -48,21 +48,21 @@ control "lambda_function_dead_letter_queue_configured" {
 control "lambda_function_in_vpc" {
   title       = "Lambda functions should be in a VPC"
   description = "Deploy AWS Lambda functions within an Amazon Virtual Private Cloud (Amazon VPC) for a secure communication between a function and other services within the Amazon VPC."
-  sql           = query.lambda_function_in_vpc.sql
+  query       = query.lambda_function_in_vpc
 
   tags = merge(local.lambda_compliance_common_tags, {
     hipaa              = "true"
     nist_800_53_rev_4  = "true"
     nist_csf           = "true"
-    pci                 = "true"
+    pci                = "true"
     rbi_cyber_security = "true"
   })
 }
 
 control "lambda_function_use_latest_runtime" {
-  title         = "Lambda functions should use latest runtimes"
-  description   = "This control checks that the Lambda function settings for runtimes match the expected values set for the latest runtimes for each supported language. This control checks for the following runtimes: nodejs14.x, nodejs12.x, nodejs10.x, python3.8, python3.7, python3.6, ruby2.7, ruby2.5,java11, java8, go1.x, dotnetcore3.1, dotnetcore2.1."
-  sql           = query.lambda_function_use_latest_runtime.sql
+  title       = "Lambda functions should use latest runtimes"
+  description = "This control checks that the Lambda function settings for runtimes match the expected values set for the latest runtimes for each supported language. This control checks for the following runtimes: nodejs14.x, nodejs12.x, nodejs10.x, python3.8, python3.7, python3.6, ruby2.7, ruby2.5,java11, java8, go1.x, dotnetcore3.1, dotnetcore2.1."
+  query       = query.lambda_function_use_latest_runtime
 
   tags = merge(local.lambda_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -72,7 +72,7 @@ control "lambda_function_use_latest_runtime" {
 control "lambda_function_xray_tracing_enabled" {
   title       = "Lambda functions xray tracing should be enabled"
   description = "X-Ray tracing in lambda functions allows you to visualize and troubleshoot errors and performance bottlenecks, and investigate requests that resulted in an error."
-  sql           = query.lambda_function_xray_tracing_enabled.sql
+  query       = query.lambda_function_xray_tracing_enabled
 
   tags = local.lambda_compliance_common_tags
 }

--- a/controls/neptune.sp
+++ b/controls/neptune.sp
@@ -14,14 +14,14 @@ benchmark "neptune" {
   ]
 
   tags = merge(local.neptune_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "neptune_cluster_logging_enabled" {
   title       = "Neptune logging should be enabled"
   description = "Ensure Neptune logging is enabled. These access logs can be used to analyze traffic patterns and troubleshoot security and operational issues."
-  sql           = query.neptune_cluster_logging_enabled.sql
+  query       = query.neptune_cluster_logging_enabled
 
   tags = local.neptune_compliance_common_tags
 }
@@ -29,7 +29,7 @@ control "neptune_cluster_logging_enabled" {
 control "neptune_cluster_encryption_at_rest_enabled" {
   title       = "Neptune cluster encryption at rest should be enabled"
   description = "Ensure Neptune clusters being created are set to be encrypted at rest to protect sensitive data."
-  sql           = query.neptune_cluster_encryption_at_rest_enabled.sql
+  query       = query.neptune_cluster_encryption_at_rest_enabled
 
   tags = local.neptune_compliance_common_tags
 }

--- a/controls/rds.sp
+++ b/controls/rds.sp
@@ -32,14 +32,14 @@ benchmark "rds" {
   ]
 
   tags = merge(local.rds_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "rds_db_cluster_aurora_backtracking_enabled" {
-  title         = "Amazon Aurora clusters should have backtracking enabled"
-  description   = "This control checks whether Amazon Aurora clusters have backtracking enabled. Backups help you to recover more quickly from a security incident. They also strengthen the resilience of your systems. Aurora backtracking reduces the time to recover a database to a point in time. It does not require a database restore to do so."
-  sql           = query.rds_db_cluster_aurora_backtracking_enabled.sql
+  title       = "Amazon Aurora clusters should have backtracking enabled"
+  description = "This control checks whether Amazon Aurora clusters have backtracking enabled. Backups help you to recover more quickly from a security incident. They also strengthen the resilience of your systems. Aurora backtracking reduces the time to recover a database to a point in time. It does not require a database restore to do so."
+  query       = query.rds_db_cluster_aurora_backtracking_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -47,9 +47,9 @@ control "rds_db_cluster_aurora_backtracking_enabled" {
 }
 
 control "rds_db_cluster_copy_tags_to_snapshot_enabled" {
-  title         = "RDS DB clusters should be configured to copy tags to snapshots"
-  description   = "This control checks whether RDS DB clusters are configured to copy all tags to snapshots when the snapshots are created."
-  sql           = query.rds_db_cluster_copy_tags_to_snapshot_enabled.sql
+  title       = "RDS DB clusters should be configured to copy tags to snapshots"
+  description = "This control checks whether RDS DB clusters are configured to copy all tags to snapshots when the snapshots are created."
+  query       = query.rds_db_cluster_copy_tags_to_snapshot_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -57,9 +57,9 @@ control "rds_db_cluster_copy_tags_to_snapshot_enabled" {
 }
 
 control "rds_db_cluster_deletion_protection_enabled" {
-  title         = "RDS clusters should have deletion protection enabled"
-  description   = "This control checks whether RDS clusters have deletion protection enabled. This control is intended for RDS DB instances. However, it can also generate findings for Aurora DB instances, Neptune DB instances, and Amazon DocumentDB clusters. If these findings are not useful,then you can suppress them."
-  sql           = query.rds_db_cluster_deletion_protection_enabled.sql
+  title       = "RDS clusters should have deletion protection enabled"
+  description = "This control checks whether RDS clusters have deletion protection enabled. This control is intended for RDS DB instances. However, it can also generate findings for Aurora DB instances, Neptune DB instances, and Amazon DocumentDB clusters. If these findings are not useful,then you can suppress them."
+  query       = query.rds_db_cluster_deletion_protection_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -67,9 +67,9 @@ control "rds_db_cluster_deletion_protection_enabled" {
 }
 
 control "rds_db_cluster_events_subscription" {
-  title         = "An RDS event notifications subscription should be configured for critical cluster events"
-  description   = "This control checks whether an Amazon RDS event subscription exists that has notifications enabled for the following source type, event category key-value pairs."
-  sql           = query.rds_db_cluster_events_subscription.sql
+  title       = "An RDS event notifications subscription should be configured for critical cluster events"
+  description = "This control checks whether an Amazon RDS event subscription exists that has notifications enabled for the following source type, event category key-value pairs."
+  query       = query.rds_db_cluster_events_subscription
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -77,9 +77,9 @@ control "rds_db_cluster_events_subscription" {
 }
 
 control "rds_db_cluster_iam_authentication_enabled" {
-  title         = "IAM authentication should be configured for RDS clusters"
-  description   = "This control checks whether an RDS DB cluster has IAM database authentication enabled. IAM database authentication allows for password-free authentication to database instances. The authentication uses an authentication token. Network traffic to and from the database is encrypted using SSL."
-  sql           = query.rds_db_cluster_iam_authentication_enabled.sql
+  title       = "IAM authentication should be configured for RDS clusters"
+  description = "This control checks whether an RDS DB cluster has IAM database authentication enabled. IAM database authentication allows for password-free authentication to database instances. The authentication uses an authentication token. Network traffic to and from the database is encrypted using SSL."
+  query       = query.rds_db_cluster_iam_authentication_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -87,9 +87,9 @@ control "rds_db_cluster_iam_authentication_enabled" {
 }
 
 control "rds_db_cluster_multiple_az_enabled" {
-  title         = "RDS DB clusters should be configured for multiple Availability Zones"
-  description   = "This control checks whether high availability is enabled for your RDS DB clusters. RDS DB clusters should be configured for multiple Availability Zones to ensure availability of the data that is stored."
-  sql           = query.rds_db_cluster_multiple_az_enabled.sql
+  title       = "RDS DB clusters should be configured for multiple Availability Zones"
+  description = "This control checks whether high availability is enabled for your RDS DB clusters. RDS DB clusters should be configured for multiple Availability Zones to ensure availability of the data that is stored."
+  query       = query.rds_db_cluster_multiple_az_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -99,18 +99,18 @@ control "rds_db_cluster_multiple_az_enabled" {
 control "rds_db_instance_and_cluster_enhanced_monitoring_enabled" {
   title       = "RDS DB instance and cluster enhanced monitoring should be enabled"
   description = "Enable Amazon Relational Database Service (Amazon RDS) to help monitor Amazon RDS availability. This provides detailed visibility into the health of your Amazon RDS database instances."
-  sql           = query.rds_db_instance_and_cluster_enhanced_monitoring_enabled.sql
+  query       = query.rds_db_instance_and_cluster_enhanced_monitoring_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
-    nist_csf = "true"
+    nist_csf                  = "true"
   })
 }
 
 control "rds_db_instance_and_cluster_no_default_port" {
-  title         = "RDS databases and clusters should not use a database engine default port"
-  description   = "This control checks whether the RDS cluster or instance uses a port other than the default port of the database engine."
-  sql           = query.rds_db_instance_and_cluster_no_default_port.sql
+  title       = "RDS databases and clusters should not use a database engine default port"
+  description = "This control checks whether the RDS cluster or instance uses a port other than the default port of the database engine."
+  query       = query.rds_db_instance_and_cluster_no_default_port
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -120,18 +120,18 @@ control "rds_db_instance_and_cluster_no_default_port" {
 control "rds_db_instance_automatic_minor_version_upgrade_enabled" {
   title       = "RDS DB instance automatic minor version upgrade should be enabled"
   description = "Ensure if Amazon Relational Database Service (RDS) database instances are configured for automatic minor version upgrades. The rule is NON_COMPLIANT if the value of 'autoMinorVersionUpgrade' is false."
-  sql           = query.rds_db_instance_automatic_minor_version_upgrade_enabled.sql
+  query       = query.rds_db_instance_automatic_minor_version_upgrade_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
-    rbi_cyber_security = "true"
+    rbi_cyber_security        = "true"
   })
 }
 
 control "rds_db_instance_backup_enabled" {
   title       = "RDS DB instance backup should be enabled"
   description = "The backup feature of Amazon RDS creates backups of your databases and transaction logs."
-  sql           = query.rds_db_instance_backup_enabled.sql
+  query       = query.rds_db_instance_backup_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     hipaa              = "true"
@@ -143,9 +143,9 @@ control "rds_db_instance_backup_enabled" {
 }
 
 control "rds_db_instance_copy_tags_to_snapshot_enabled" {
-  title         = "RDS DB instances should be configured to copy tags to snapshots"
-  description   = "This control checks whether RDS DB instances are configured to copy all tags to snapshots when the snapshots are created."
-  sql           = query.rds_db_instance_copy_tags_to_snapshot_enabled.sql
+  title       = "RDS DB instances should be configured to copy tags to snapshots"
+  description = "This control checks whether RDS DB instances are configured to copy all tags to snapshots when the snapshots are created."
+  query       = query.rds_db_instance_copy_tags_to_snapshot_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -155,35 +155,35 @@ control "rds_db_instance_copy_tags_to_snapshot_enabled" {
 control "rds_db_instance_deletion_protection_enabled" {
   title       = "RDS DB instances should have deletion protection enabled"
   description = "Ensure Amazon Relational Database Service (Amazon RDS) instances have deletion protection enabled."
-  sql           = query.rds_db_instance_deletion_protection_enabled.sql
+  query       = query.rds_db_instance_deletion_protection_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
-    nist_800_53_rev_4 = "true"
-    soc_2             = "true"
+    nist_800_53_rev_4         = "true"
+    soc_2                     = "true"
   })
 }
 
 control "rds_db_instance_encryption_at_rest_enabled" {
   title       = "RDS DB instance encryption at rest should be enabled"
   description = "To help protect data at rest, ensure that encryption is enabled for your Amazon Relational Database Service (Amazon RDS) instances."
-  sql           = query.rds_db_instance_encryption_at_rest_enabled.sql
+  query       = query.rds_db_instance_encryption_at_rest_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
-    cis = "true"
-    gdpr               = "true"
-    hipaa              = "true"
-    nist_800_53_rev_4  = "true"
-    nist_csf           = "true"
-    rbi_cyber_security = "true"
+    cis                       = "true"
+    gdpr                      = "true"
+    hipaa                     = "true"
+    nist_800_53_rev_4         = "true"
+    nist_csf                  = "true"
+    rbi_cyber_security        = "true"
   })
 }
 
 control "rds_db_instance_events_subscription" {
-  title         = "An RDS event notifications subscription should be configured for critical database instance events"
-  description   = "This control checks whether an Amazon RDS event subscription exists with notifications enabled for the following source type, event category key-value pairs."
-  sql           = query.rds_db_instance_events_subscription.sql
+  title       = "An RDS event notifications subscription should be configured for critical database instance events"
+  description = "This control checks whether an Amazon RDS event subscription exists with notifications enabled for the following source type, event category key-value pairs."
+  query       = query.rds_db_instance_events_subscription
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -193,32 +193,32 @@ control "rds_db_instance_events_subscription" {
 control "rds_db_instance_iam_authentication_enabled" {
   title       = "RDS DB instances should have iam authentication enabled"
   description = "Checks if an Amazon Relational Database Service (Amazon RDS) instance has AWS Identity and Access Management (IAM) authentication enabled."
-  sql           = query.rds_db_instance_iam_authentication_enabled.sql
+  query       = query.rds_db_instance_iam_authentication_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
-    soc_2  = "true"
+    soc_2                     = "true"
   })
 }
 
 control "rds_db_instance_logging_enabled" {
   title       = "Database logging should be enabled"
   description = "To help with logging and monitoring within your environment, ensure Amazon Relational Database Service (Amazon RDS) logging is enabled."
-  sql           = query.rds_db_instance_logging_enabled.sql
+  query       = query.rds_db_instance_logging_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
-    gdpr               = "true"
-    nist_800_53_rev_4  = "true"
-    rbi_cyber_security = "true"
-    soc_2              = "true"
+    gdpr                      = "true"
+    nist_800_53_rev_4         = "true"
+    rbi_cyber_security        = "true"
+    soc_2                     = "true"
   })
 }
 
 control "rds_db_instance_multiple_az_enabled" {
   title       = "RDS DB instance multiple az should be enabled"
   description = "Multi-AZ support in Amazon Relational Database Service (Amazon RDS) provides enhanced availability and durability for database instances."
-  sql           = query.rds_db_instance_multiple_az_enabled.sql
+  query       = query.rds_db_instance_multiple_az_enabled
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -231,23 +231,23 @@ control "rds_db_instance_multiple_az_enabled" {
 control "rds_db_instance_prohibit_public_access" {
   title       = "RDS DB instances should prohibit public access"
   description = "Manage access to resources in the AWS Cloud by ensuring that Amazon Relational Database Service (Amazon RDS) instances are not public."
-  sql           = query.rds_db_instance_prohibit_public_access.sql
+  query       = query.rds_db_instance_prohibit_public_access
 
   tags = merge(local.rds_compliance_common_tags, {
-    aws_foundational_security   = "true"
-    hipaa                       = "true"
-    nist_800_53_rev_4           = "true"
-    nist_csf                    = "true"
-    rbi_cyber_security          = "true"
-    pci                         = "true"
-    soc_2                       = "true"
+    aws_foundational_security = "true"
+    hipaa                     = "true"
+    nist_800_53_rev_4         = "true"
+    nist_csf                  = "true"
+    rbi_cyber_security        = "true"
+    pci                       = "true"
+    soc_2                     = "true"
   })
 }
 
 control "rds_db_parameter_group_events_subscription" {
-  title         = "An RDS event notifications subscription should be configured for critical database parameter group events"
-  description   = "This control checks whether an Amazon RDS event subscription exists with notifications enabled for the following source type, event category key-value pairs."
-  sql           = query.rds_db_parameter_group_events_subscription.sql
+  title       = "An RDS event notifications subscription should be configured for critical database parameter group events"
+  description = "This control checks whether an Amazon RDS event subscription exists with notifications enabled for the following source type, event category key-value pairs."
+  query       = query.rds_db_parameter_group_events_subscription
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -255,9 +255,9 @@ control "rds_db_parameter_group_events_subscription" {
 }
 
 control "rds_db_security_group_events_subscription" {
-  title         = "An RDS event notifications subscription should be configured for critical database security group events"
-  description   = "This control checks whether an Amazon RDS event subscription exists with notifications enabled for the following source type, event category key-value pairs."
-  sql           = query.rds_db_security_group_events_subscription.sql
+  title       = "An RDS event notifications subscription should be configured for critical database security group events"
+  description = "This control checks whether an Amazon RDS event subscription exists with notifications enabled for the following source type, event category key-value pairs."
+  query       = query.rds_db_security_group_events_subscription
 
   tags = merge(local.rds_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/redshift.sp
+++ b/controls/redshift.sp
@@ -21,14 +21,14 @@ benchmark "redshift" {
   ]
 
   tags = merge(local.redshift_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "redshift_cluster_automatic_snapshots_min_7_days" {
   title       = "Amazon Redshift clusters should have automatic snapshots enabled"
   description = "This control checks whether Amazon Redshift clusters have automated snapshots enabled. It also checks whether the snapshot retention period is greater than or equal to seven."
-  sql         = query.redshift_cluster_automatic_snapshots_min_7_days.sql
+  query       = query.redshift_cluster_automatic_snapshots_min_7_days
 
   tags = merge(local.redshift_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -43,7 +43,7 @@ control "redshift_cluster_automatic_snapshots_min_7_days" {
 control "redshift_cluster_automatic_upgrade_major_versions_enabled" {
   title       = "Amazon Redshift should have automatic upgrades to major versions enabled"
   description = "This control checks whether automatic major version upgrades are enabled for the Amazon Redshift cluster."
-  sql         = query.redshift_cluster_automatic_upgrade_major_versions_enabled.sql
+  query       = query.redshift_cluster_automatic_upgrade_major_versions_enabled
 
   tags = merge(local.redshift_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -53,7 +53,7 @@ control "redshift_cluster_automatic_upgrade_major_versions_enabled" {
 control "redshift_cluster_deployed_in_ec2_classic_mode" {
   title       = "Redshift clusters should not be using EC2 classic mode"
   description = "Ensure EC2-Classic mode is not used for the deployment of redshift clusters"
-  sql         = query.redshift_cluster_deployed_in_ec2_classic_mode.sql
+  query       = query.redshift_cluster_deployed_in_ec2_classic_mode
 
   tags = local.redshift_compliance_common_tags
 }
@@ -61,7 +61,7 @@ control "redshift_cluster_deployed_in_ec2_classic_mode" {
 control "redshift_cluster_encryption_logging_enabled" {
   title       = "Redshift cluster audit logging and encryption should be enabled"
   description = "To protect data at rest, ensure that encryption is enabled for your Amazon Redshift clusters. You must also ensure that required configurations are deployed on Amazon Redshift clusters. The audit logging should be enabled to provide information about connections and user activities in the database."
-  sql         = query.redshift_cluster_encryption_logging_enabled.sql
+  query       = query.redshift_cluster_encryption_logging_enabled
 
   tags = merge(local.redshift_compliance_common_tags, {
     soc_2 = "true"
@@ -71,7 +71,7 @@ control "redshift_cluster_encryption_logging_enabled" {
 control "redshift_cluster_enhanced_vpc_routing_enabled" {
   title       = "Amazon Redshift clusters should use enhanced VPC routing"
   description = "This control checks whether an Amazon Redshift cluster has EnhancedVpcRouting enabled."
-  sql         = query.redshift_cluster_enhanced_vpc_routing_enabled.sql
+  query       = query.redshift_cluster_enhanced_vpc_routing_enabled
 
   tags = merge(local.redshift_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -81,7 +81,7 @@ control "redshift_cluster_enhanced_vpc_routing_enabled" {
 control "redshift_cluster_kms_enabled" {
   title       = "Amazon Redshift clusters should be encrypted with KMS"
   description = "Ensure if Amazon Redshift clusters are using a specified AWS Key Management Service (AWS KMS) key for encryption. The rule is complaint if encryption is enabled and the cluster is encrypted with the key provided in the kmsKeyArn parameter. The rule is non complaint if the cluster is not encrypted or encrypted with another key."
-  sql         = query.redshift_cluster_kms_enabled.sql
+  query       = query.redshift_cluster_kms_enabled
 
   tags = merge(local.redshift_compliance_common_tags, {
     rbi_cyber_security = "true"
@@ -91,7 +91,7 @@ control "redshift_cluster_kms_enabled" {
 control "redshift_cluster_logging_enabled" {
   title       = "Amazon Redshift clusters should have logging enabled"
   description = "Ensure that Amazon Redshift clusters have logging enabled."
-  sql         = query.redshift_cluster_logging_enabled.sql
+  query       = query.redshift_cluster_logging_enabled
 
   tags = local.redshift_compliance_common_tags
 }
@@ -99,7 +99,7 @@ control "redshift_cluster_logging_enabled" {
 control "redshift_cluster_maintenance_settings_check" {
   title       = "Amazon Redshift should have required maintenance settings"
   description = "Ensure whether Amazon Redshift clusters have the specified maintenance settings. Redshift clusters 'allowVersionUpgrade' should be set to 'true' and 'automatedSnapshotRetentionPeriod' should be greater than 7."
-  sql         = query.redshift_cluster_maintenance_settings_check.sql
+  query       = query.redshift_cluster_maintenance_settings_check
 
   tags = merge(local.redshift_compliance_common_tags, {
     rbi_cyber_security = "true"
@@ -109,7 +109,7 @@ control "redshift_cluster_maintenance_settings_check" {
 control "redshift_cluster_prohibit_public_access" {
   title       = "Redshift clusters should prohibit public access"
   description = "Manage access to resources in the AWS Cloud by ensuring that Amazon Redshift clusters are not public."
-  sql         = query.redshift_cluster_prohibit_public_access.sql
+  query       = query.redshift_cluster_prohibit_public_access
 
   tags = merge(local.redshift_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/s3.sp
+++ b/controls/s3.sp
@@ -21,14 +21,14 @@ benchmark "s3" {
   ]
 
   tags = merge(local.s3_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "s3_bucket_cross_region_replication_enabled" {
   title       = "S3 bucket cross-region replication should enabled"
   description = "Amazon Simple Storage Service (Amazon S3) Cross-Region Replication (CRR) supports maintaining adequate capacity and availability."
-  sql           = query.s3_bucket_cross_region_replication_enabled.sql
+  query       = query.s3_bucket_cross_region_replication_enabled
 
   tags = merge(local.s3_compliance_common_tags, {
     hipaa              = "true"
@@ -43,7 +43,7 @@ control "s3_bucket_cross_region_replication_enabled" {
 control "s3_bucket_default_encryption_enabled_kms" {
   title       = "S3 bucket default encryption should be enabled with KMS"
   description = "To help protect data at rest, ensure encryption is enabled for your Amazon Simple Storage Service (Amazon S3) buckets using KMS."
-  sql           = query.s3_bucket_default_encryption_enabled_kms.sql
+  query       = query.s3_bucket_default_encryption_enabled_kms
 
   tags = merge(local.s3_compliance_common_tags, {
     gdpr               = "true"
@@ -55,7 +55,7 @@ control "s3_bucket_default_encryption_enabled_kms" {
 control "s3_bucket_default_encryption_enabled" {
   title       = "S3 bucket default encryption should be enabled"
   description = "To help protect data at rest, ensure default encryption is enabled for your Amazon Simple Storage Service (Amazon S3) buckets."
-  sql           = query.s3_bucket_default_encryption_enabled.sql
+  query       = query.s3_bucket_default_encryption_enabled
 
   tags = merge(local.s3_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -70,9 +70,9 @@ control "s3_bucket_default_encryption_enabled" {
 }
 
 control "s3_bucket_logging_enabled" {
-   title       = "S3 bucket logging should be enabled"
+  title       = "S3 bucket logging should be enabled"
   description = "Amazon Simple Storage Service (Amazon S3) server access logging provides a method to monitor the network for potential cybersecurity events."
-  sql           = query.s3_bucket_logging_enabled.sql
+  query       = query.s3_bucket_logging_enabled
 
   tags = merge(local.s3_compliance_common_tags, {
     hipaa              = "true"
@@ -84,9 +84,9 @@ control "s3_bucket_logging_enabled" {
 }
 
 control "s3_bucket_mfa_delete_enabled" {
-  title         = "Ensure MFA Delete is enabled on S3 buckets"
-  description   = "Once MFA delete is enabled on your sensitive and classified S3 bucket it requires the user to have two forms of authentication."
-  sql           = query.s3_bucket_mfa_delete_enabled.sql
+  title       = "Ensure MFA Delete is enabled on S3 buckets"
+  description = "Once MFA delete is enabled on your sensitive and classified S3 bucket it requires the user to have two forms of authentication."
+  query       = query.s3_bucket_mfa_delete_enabled
 
   tags = merge(local.s3_compliance_common_tags, {
     cis = "true"
@@ -96,7 +96,7 @@ control "s3_bucket_mfa_delete_enabled" {
 control "s3_bucket_object_lock_enabled" {
   title       = "S3 bucket object lock should be enabled"
   description = "Ensure that your Amazon Simple Storage Service (Amazon S3) bucket has lock enabled, by default."
-  sql           = query.s3_bucket_object_lock_enabled.sql
+  query       = query.s3_bucket_object_lock_enabled
 
   tags = merge(local.s3_compliance_common_tags, {
     hipaa    = "true"
@@ -106,9 +106,9 @@ control "s3_bucket_object_lock_enabled" {
 }
 
 control "s3_bucket_public_access_blocked" {
-  title         = "S3 Block Public Access setting should be enabled at the bucket level"
-  description   = "This control checks whether S3 buckets have bucket-level public access blocks applied."
-  sql           = query.s3_bucket_public_access_blocked.sql
+  title       = "S3 Block Public Access setting should be enabled at the bucket level"
+  description = "This control checks whether S3 buckets have bucket-level public access blocks applied."
+  query       = query.s3_bucket_public_access_blocked
 
   tags = merge(local.s3_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -118,20 +118,20 @@ control "s3_bucket_public_access_blocked" {
 control "s3_bucket_versioning_enabled" {
   title       = "S3 bucket versioning should be enabled"
   description = "Amazon Simple Storage Service (Amazon S3) bucket versioning helps keep multiple variants of an object in the same Amazon S3 bucket."
-  sql           = query.s3_bucket_versioning_enabled.sql
+  query       = query.s3_bucket_versioning_enabled
 
   tags = merge(local.s3_compliance_common_tags, {
-    hipaa                       = "true"
-    nist_csf                    = "true"
-    rbi_cyber_security          = "true"
-    soc_2                       = "true"
+    hipaa              = "true"
+    nist_csf           = "true"
+    rbi_cyber_security = "true"
+    soc_2              = "true"
   })
 }
 
 control "s3_public_access_block_account" {
   title       = "S3 public access should be blocked at account level"
   description = "Manage access to resources in the AWS Cloud by ensuring that Amazon Simple Storage Service (Amazon S3) buckets cannot be publicly accessed."
-  sql           = query.s3_public_access_block_account.sql
+  query       = query.s3_public_access_block_account
 
   tags = merge(local.s3_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/sagemaker.sp
+++ b/controls/sagemaker.sp
@@ -15,14 +15,14 @@ benchmark "sagemaker" {
   ]
 
   tags = merge(local.sagemaker_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "sagemaker_endpoint_configuration_encryption_at_rest_enabled" {
   title       = "SageMaker endpoint configuration encryption should be enabled"
   description = "To help protect data at rest, ensure encryption with AWS Key Management Service (AWS KMS) is enabled for your SageMaker endpoint."
-  sql           = query.sagemaker_endpoint_configuration_encryption_at_rest_enabled.sql
+  query       = query.sagemaker_endpoint_configuration_encryption_at_rest_enabled
 
   tags = merge(local.sagemaker_compliance_common_tags, {
     gdpr               = "true"
@@ -36,7 +36,7 @@ control "sagemaker_endpoint_configuration_encryption_at_rest_enabled" {
 control "sagemaker_notebook_instance_direct_internet_access_disabled" {
   title       = "SageMaker notebook instances should not have direct internet access"
   description = "Manage access to resources in the AWS Cloud by ensuring that Amazon SageMaker notebooks do not allow direct internet access."
-  sql           = query.sagemaker_notebook_instance_direct_internet_access_disabled.sql
+  query       = query.sagemaker_notebook_instance_direct_internet_access_disabled
 
   tags = merge(local.sagemaker_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -51,7 +51,7 @@ control "sagemaker_notebook_instance_direct_internet_access_disabled" {
 control "sagemaker_notebook_instance_encryption_at_rest_enabled" {
   title       = "SageMaker notebook instance encryption should be enabled"
   description = "To help protect data at rest, ensure encryption with AWS Key Management Service (AWS KMS) is enabled for your SageMaker notebook."
-  sql           = query.sagemaker_notebook_instance_encryption_at_rest_enabled.sql
+  query       = query.sagemaker_notebook_instance_encryption_at_rest_enabled
 
   tags = merge(local.sagemaker_compliance_common_tags, {
     gdpr               = "true"

--- a/controls/secretsmanager.sp
+++ b/controls/secretsmanager.sp
@@ -15,14 +15,14 @@ benchmark "secretsmanager" {
   ]
 
   tags = merge(local.secretsmanager_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "secretsmanager_secret_automatic_rotation_enabled" {
   title       = "Secrets Manager secrets should have automatic rotation enabled"
   description = "This rule ensures AWS Secrets Manager secrets have rotation enabled. Rotating secrets on a regular schedule can shorten the period a secret is active, and potentially reduce the business impact if the secret is compromised."
-  sql           = query.secretsmanager_secret_automatic_rotation_enabled.sql
+  query       = query.secretsmanager_secret_automatic_rotation_enabled
 
   tags = merge(local.secretsmanager_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -32,9 +32,9 @@ control "secretsmanager_secret_automatic_rotation_enabled" {
 }
 
 control "secretsmanager_secret_automatic_rotation_lambda_enabled" {
-  title         = "Secrets Manager secrets should be rotated within a specified number of days"
-  description   = "This control checks whether your secrets have been rotated at least once within 90 days. Rotating secrets can help you to reduce the risk of an unauthorized use of your secrets in your AWS account. Examples include database credentials, passwords, third-party API keys, and even arbitrary text. If you do not change your secrets for a long period of time, the secrets are more likely to be compromised."
-  sql           = query.secretsmanager_secret_automatic_rotation_lambda_enabled.sql
+  title       = "Secrets Manager secrets should be rotated within a specified number of days"
+  description = "This control checks whether your secrets have been rotated at least once within 90 days. Rotating secrets can help you to reduce the risk of an unauthorized use of your secrets in your AWS account. Examples include database credentials, passwords, third-party API keys, and even arbitrary text. If you do not change your secrets for a long period of time, the secrets are more likely to be compromised."
+  query       = query.secretsmanager_secret_automatic_rotation_lambda_enabled
 
   tags = merge(local.secretsmanager_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -42,9 +42,9 @@ control "secretsmanager_secret_automatic_rotation_lambda_enabled" {
 }
 
 control "secretsmanager_secret_encrypted_with_kms_cmk" {
-  title         = "Secrets Manager secrets should be encrypted with KMS CMK"
-  description   = "Ensure Secrets Manager secrets are encrypted at rest with customer-managed CMK."
-  sql           = query.secretsmanager_secret_encrypted_with_kms_cmk.sql
+  title       = "Secrets Manager secrets should be encrypted with KMS CMK"
+  description = "Ensure Secrets Manager secrets are encrypted at rest with customer-managed CMK."
+  query       = query.secretsmanager_secret_encrypted_with_kms_cmk
 
   tags = local.secretsmanager_compliance_common_tags
 }

--- a/controls/sns.sp
+++ b/controls/sns.sp
@@ -13,14 +13,14 @@ benchmark "sns" {
   ]
 
   tags = merge(local.sns_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "sns_topic_encrypted_at_rest" {
   title       = "SNS topics should be encrypted at rest"
   description = "To help protect data at rest, ensure that your Amazon Simple Notification Service (Amazon SNS) topics require encryption using AWS Key Management Service (AWS KMS)."
-  sql           = query.sns_topic_encrypted_at_rest.sql
+  query       = query.sns_topic_encrypted_at_rest
 
   tags = merge(local.sns_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/sqs.sp
+++ b/controls/sqs.sp
@@ -14,24 +14,24 @@ benchmark "sqs" {
   ]
 
   tags = merge(local.sqs_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "sqs_queue_encrypted_at_rest" {
-  title         = "Amazon SQS queues should be encrypted at rest"
-  description   = "This control checks whether Amazon SQS queues are encrypted at rest."
-  sql           = query.sqs_queue_encrypted_at_rest.sql
+  title       = "Amazon SQS queues should be encrypted at rest"
+  description = "This control checks whether Amazon SQS queues are encrypted at rest."
+  query       = query.sqs_queue_encrypted_at_rest
 
   tags = merge(local.sqs_compliance_common_tags, {
-    aws_foundational_security  = "true"
+    aws_foundational_security = "true"
   })
 }
 
 control "sqs_vpc_endpoint_without_dns_resolution" {
   title       = "VPC Endpoint for SQS should be enabled in all Availability Zones in use a VPC"
   description = "Using VPC endpoints helps secure traffic by ensuring the data does not traverse the Internet or access public networks. It also helps keep private subnets private. Setting up VPC endpoints can be complicated."
-  sql           = query.sqs_vpc_endpoint_without_dns_resolution.sql
+  query       = query.sqs_vpc_endpoint_without_dns_resolution
 
   tags = local.sqs_compliance_common_tags
 }

--- a/controls/vpc.sp
+++ b/controls/vpc.sp
@@ -21,14 +21,14 @@ benchmark "vpc" {
   ]
 
   tags = merge(local.vpc_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "vpc_default_security_group_restricts_all_traffic" {
   title       = "VPC default security group should not allow inbound and outbound traffic"
   description = "Amazon Elastic Compute Cloud (Amazon EC2) security groups can help in the management of network access by providing stateful filtering of ingress and egress network traffic to AWS resources."
-  sql           = query.vpc_default_security_group_restricts_all_traffic.sql
+  query       = query.vpc_default_security_group_restricts_all_traffic
 
   tags = merge(local.vpc_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -43,7 +43,7 @@ control "vpc_default_security_group_restricts_all_traffic" {
 control "vpc_eip_associated" {
   title       = "VPC EIPs should be associated with an EC2 instance or ENI"
   description = "This rule ensures Elastic IPs allocated to a Amazon Virtual Private Cloud (Amazon VPC) are attached to Amazon Elastic Compute Cloud (Amazon EC2) instances or in-use Elastic Network Interfaces."
-  sql           = query.vpc_eip_associated.sql
+  query       = query.vpc_eip_associated
 
   tags = merge(local.vpc_compliance_common_tags, {
     nist_csf = "true"
@@ -54,7 +54,7 @@ control "vpc_eip_associated" {
 control "vpc_flow_logs_enabled" {
   title       = "VPC flow logs should be enabled"
   description = "The VPC flow logs provide detailed records for information about the IP traffic going to and from network interfaces in your Amazon Virtual Private Cloud (Amazon VPC."
-  sql           = query.vpc_flow_logs_enabled.sql
+  query       = query.vpc_flow_logs_enabled
 
   tags = merge(local.vpc_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -72,7 +72,7 @@ control "vpc_flow_logs_enabled" {
 control "vpc_igw_attached_to_authorized_vpc" {
   title       = "VPC internet gateways should be attached to authorized vpc"
   description = "Manage access to resources in the AWS Cloud by ensuring that internet gateways are only attached to authorized Amazon Virtual Private Cloud (Amazon VPC)."
-  sql           = query.vpc_igw_attached_to_authorized_vpc.sql
+  query       = query.vpc_igw_attached_to_authorized_vpc
 
   tags = merge(local.vpc_compliance_common_tags, {
     hipaa              = "true"
@@ -83,9 +83,9 @@ control "vpc_igw_attached_to_authorized_vpc" {
 }
 
 control "vpc_network_acl_unused" {
-  title         = "Unused network access control lists should be removed"
-  description   = "This control checks whether there are any unused network access control lists (ACLs). The control checks the item configuration of the resource AWS::EC2::NetworkAcl and determines the relationships of the network ACL."
-  sql           = query.vpc_network_acl_unused.sql
+  title       = "Unused network access control lists should be removed"
+  description = "This control checks whether there are any unused network access control lists (ACLs). The control checks the item configuration of the resource AWS::EC2::NetworkAcl and determines the relationships of the network ACL."
+  query       = query.vpc_network_acl_unused
 
   tags = merge(local.vpc_compliance_common_tags, {
     aws_foundational_security = "true"
@@ -95,7 +95,7 @@ control "vpc_network_acl_unused" {
 control "vpc_security_group_associated_to_eni" {
   title       = "VPC security groups should be associated with at least one ENI"
   description = "This rule ensures the security groups are attached to an Amazon Elastic Compute Cloud (Amazon EC2) instance or to an ENI. This rule helps monitoring unused security groups in the inventory and the management of your environment."
-  sql           = query.vpc_security_group_associated_to_eni.sql
+  query       = query.vpc_security_group_associated_to_eni
 
   tags = merge(local.vpc_compliance_common_tags, {
     nist_csf = "true"
@@ -103,17 +103,17 @@ control "vpc_security_group_associated_to_eni" {
 }
 
 control "vpc_security_group_description_for_rules" {
-  title         = "VPC security group should have description for rules"
-  description   = "One of the best practices when creating security groups in AWS is to add a description to the group for better clarity."
-  sql           = query.vpc_security_group_description_for_rules.sql
+  title       = "VPC security group should have description for rules"
+  description = "One of the best practices when creating security groups in AWS is to add a description to the group for better clarity."
+  query       = query.vpc_security_group_description_for_rules
 
   tags = local.vpc_compliance_common_tags
 }
 
 control "vpc_security_group_rule_description_for_rules" {
-  title         = "VPC security group rule should have description for rules"
-  description   = "One of the best practices when creating security groups rule in AWS is to add a description to the group and each of its rules for better clarity."
-  sql           = query.vpc_security_group_rule_description_for_rules.sql
+  title       = "VPC security group rule should have description for rules"
+  description = "One of the best practices when creating security groups rule in AWS is to add a description to the group and each of its rules for better clarity."
+  query       = query.vpc_security_group_rule_description_for_rules
 
   tags = local.vpc_compliance_common_tags
 }
@@ -121,7 +121,7 @@ control "vpc_security_group_rule_description_for_rules" {
 control "vpc_subnet_auto_assign_public_ip_disabled" {
   title       = "VPC subnet auto assign public IP should be disabled"
   description = "Ensure if Amazon Virtual Private Cloud (Amazon VPC) subnets are assigned a public IP address. The control is complaint if Amazon VPC does not have subnets that are assigned a public IP address."
-  sql           = query.vpc_subnet_auto_assign_public_ip_disabled.sql
+  query       = query.vpc_subnet_auto_assign_public_ip_disabled
 
   tags = merge(local.vpc_compliance_common_tags, {
     aws_foundational_security = "true"

--- a/controls/workspace.sp
+++ b/controls/workspace.sp
@@ -14,14 +14,14 @@ benchmark "workspace" {
   ]
 
   tags = merge(local.workspace_compliance_common_tags, {
-    type    = "Benchmark"
+    type = "Benchmark"
   })
 }
 
 control "workspace_root_volume_encryption_at_rest_enabled" {
   title       = "AWS workspaces root volume should be encrypted at rest"
   description = "Ensure Workspaces being created are set to encrypt root volume at rest."
-  sql           = query.workspace_root_volume_encryption_at_rest_enabled.sql
+  query       = query.workspace_root_volume_encryption_at_rest_enabled
 
   tags = local.workspace_compliance_common_tags
 
@@ -30,7 +30,7 @@ control "workspace_root_volume_encryption_at_rest_enabled" {
 control "workspace_user_volume_encryption_at_rest_enabled" {
   title       = "AWS workspaces user volume should be encrypted at rest"
   description = "Ensure Workspaces being created are set to encrypt user volume at rest."
-  sql           = query.workspace_user_volume_encryption_at_rest_enabled.sql
+  query       = query.workspace_user_volume_encryption_at_rest_enabled
 
   tags = local.workspace_compliance_common_tags
 


### PR DESCRIPTION
This occurs throughout the mod, but as a specific example:

```sql
control "athena_database_encryption_at_rest_enabled" { 
title       = "Athena database encryption at rest should be enabled" 
description = "Ensure Athena database is encrypted at rest to protect sensitive data." 
sql           = query.athena_database_encryption_at_rest_enabled.sql 

tags = local.athena_compliance_common_tags 
  
} 
```
This is changed from:
```
sql           = query.athena_database_encryption_at_rest_enabled.sql
```
to:
```
query         = query.athena_database_encryption_at_rest_enabled
```