### PR TITLE
Add additional services specific controls. Closes #64

### DIFF
--- a/controls/acm.sp
+++ b/controls/acm.sp
@@ -1,0 +1,36 @@
+locals {
+  acm_compliance_common_tags = merge(local.terraform_aws_compliance_common_tags, {
+    service = "AWS/ACM"
+  })
+}
+
+benchmark "acm" {
+  title       = "ACM"
+  description = "This benchmark provides a set of controls that detect Terraform AWS ACM resources deviating from security best practices."
+
+  children = [
+    control.acm_certificate_create_before_destroy_enabled,
+    control.acm_certificate_transparency_logging_enabled
+  ]
+
+  tags = merge(local.acm_compliance_common_tags, {
+    type = "Benchmark"
+  })
+}
+
+control "acm_certificate_create_before_destroy_enabled" {
+  title       = "ACM certificate should have create before destroy enabled"
+  description = "This control checks whether ACM certificate has create before destroy enabled. It is recommended to enable the resource lifecycle configuration block create_before_destroy argument in this resource configuration to manage all requests that use this certificate, avoiding an outage."
+  query       = query.acm_certificate_create_before_destroy_enabled
+  tags        = local.acm_compliance_common_tags
+}
+
+control "acm_certificate_transparency_logging_enabled" {
+  title       = "ACM certificates should have transparency logging preference enabled"
+  description = "Ensure ACM certificates transparency logging preference is enabled as certificate transparency logging guards against SSL/TLS certificates issued by mistake or by a compromised certificate authority."
+  query       = query.acm_certificate_transparency_logging_enabled
+
+  tags = merge(local.acm_compliance_common_tags, {
+    other_checks = "true"
+  })
+}

--- a/controls/acm.sp
+++ b/controls/acm.sp
@@ -27,7 +27,7 @@ control "acm_certificate_create_before_destroy_enabled" {
 
 control "acm_certificate_transparency_logging_enabled" {
   title       = "ACM certificates should have transparency logging preference enabled"
-  description = "Ensure ACM certificates transparency logging preference is enabled as certificate transparency logging guards against SSL/TLS certificates issued by mistake or by a compromised certificate authority."
+  description = "This control checks whether ACM certificates transparency logging preference is enabled as certificate transparency logging guards against SSL/TLS certificates issued by mistake or by a compromised certificate authority."
   query       = query.acm_certificate_transparency_logging_enabled
 
   tags = merge(local.acm_compliance_common_tags, {

--- a/controls/appflow.sp
+++ b/controls/appflow.sp
@@ -1,0 +1,25 @@
+locals {
+  appflow_compliance_common_tags = merge(local.terraform_aws_compliance_common_tags, {
+    service = "AWS/AppFlow"
+  })
+}
+
+benchmark "appflow" {
+  title       = "AppFlow"
+  description = "This benchmark provides a set of controls that detect Terraform AWS AppFlow resources deviating from security best practices."
+
+  children = [
+    control.appflow_flow_encrypted_with_kms_cmk
+  ]
+
+  tags = merge(local.appflow_compliance_common_tags, {
+    type = "Benchmark"
+  })
+}
+
+control "appflow_flow_encrypted_with_kms_cmk" {
+  title       = "AppFlow should be encrypted with KMS CMK"
+  description = "This control checks whether AppFlow is encrypted with KMS CMK."
+  query       = query.appflow_flow_encrypted_with_kms_cmk
+  tags = local.appflow_compliance_common_tags
+}

--- a/controls/appflow.sp
+++ b/controls/appflow.sp
@@ -19,8 +19,8 @@ benchmark "appflow" {
 }
 
 control "appflow_flow_encrypted_with_kms_cmk" {
-  title       = "AppFlow should be encrypted with KMS CMK"
-  description = "This control checks whether AppFlow is encrypted with KMS CMK."
+  title       = "AppFlow Flow should be encrypted with KMS CMK"
+  description = "This control checks whether AppFlow Flow is encrypted with KMS CMK."
   query       = query.appflow_flow_encrypted_with_kms_cmk
 
   tags = local.appflow_compliance_common_tags

--- a/controls/appflow.sp
+++ b/controls/appflow.sp
@@ -9,6 +9,7 @@ benchmark "appflow" {
   description = "This benchmark provides a set of controls that detect Terraform AWS AppFlow resources deviating from security best practices."
 
   children = [
+    control.appflow_connector_profile_encrypted_with_kms_cmk,
     control.appflow_flow_encrypted_with_kms_cmk
   ]
 
@@ -21,5 +22,14 @@ control "appflow_flow_encrypted_with_kms_cmk" {
   title       = "AppFlow should be encrypted with KMS CMK"
   description = "This control checks whether AppFlow is encrypted with KMS CMK."
   query       = query.appflow_flow_encrypted_with_kms_cmk
+
+  tags = local.appflow_compliance_common_tags
+}
+
+control "appflow_connector_profile_encrypted_with_kms_cmk" {
+  title       = "AppFlow Connector Profile should be encrypted with KMS CMK"
+  description = "This control checks whether AppFlow Connector Profile is encrypted with KMS CMK."
+  query       = query.appflow_connector_profile_encrypted_with_kms_cmk
+
   tags = local.appflow_compliance_common_tags
 }

--- a/controls/athena.sp
+++ b/controls/athena.sp
@@ -39,7 +39,7 @@ control "athena_workgroup_encryption_at_rest_enabled" {
 
 control "athena_workgroup_enforce_workgroup_configuration" {
   title       = "Athena workgroup configuration should be enforced"
-  description = "Ensure Athena Workgroup should enforce configuration to prevent client disabling encryption."
+  description = "This control checks whether Athena Workgroup should enforce configuration to prevent client disabling encryption."
   query       = query.athena_workgroup_enforce_workgroup_configuration
 
   tags = local.athena_compliance_common_tags

--- a/controls/athena.sp
+++ b/controls/athena.sp
@@ -10,7 +10,8 @@ benchmark "athena" {
 
   children = [
     control.athena_database_encryption_at_rest_enabled,
-    control.athena_workgroup_encryption_at_rest_enabled
+    control.athena_workgroup_encryption_at_rest_enabled,
+    control.athena_workgroup_enforce_workgroup_configuration
   ]
 
   tags = merge(local.athena_compliance_common_tags, {
@@ -31,6 +32,15 @@ control "athena_workgroup_encryption_at_rest_enabled" {
   title       = "Athena workgroup encryption at rest should be enabled"
   description = "Ensure Athena workgroup is encrypted at rest to protect sensitive data."
   query       = query.athena_workgroup_encryption_at_rest_enabled
+
+  tags = local.athena_compliance_common_tags
+
+}
+
+control "athena_workgroup_enforce_workgroup_configuration" {
+  title       = "Athena workgroup configuration should be enforced"
+  description = "Ensure Athena Workgroup should enforce configuration to prevent client disabling encryption."
+  query       = query.athena_workgroup_enforce_workgroup_configuration
 
   tags = local.athena_compliance_common_tags
 

--- a/controls/cloudformation.sp
+++ b/controls/cloudformation.sp
@@ -1,0 +1,30 @@
+locals {
+  cloudformation_compliance_common_tags = merge(local.terraform_aws_compliance_common_tags, {
+    service = "AWS/CloudFormation"
+  })
+}
+
+benchmark "cloudformation" {
+  title       = "CloudFormation"
+  description = "This benchmark provides a set of controls that detect Terraform AWS CloudFormation resources deviating from security best practices."
+
+  children = [
+    control.acm_certificate_create_before_destroy_enabled,
+    control.cloudsearch_domain_uses_latest_tls_version
+  ]
+
+  tags = merge(local.cloudformation_compliance_common_tags, {
+    type = "Benchmark"
+  })
+}
+
+control "cloudformation_stack_notifications_enabled" {
+  title       = "CloudFormation stacks should have notifications enabled"
+  description = "This control checks whether CloudFormation stacks are associated with an SNS topic to receive notifications when an event occurs."
+  query       = query.cloudformation_stack_notifications_enabled
+
+  tags = merge(local.cloudformation_compliance_common_tags, {
+    nist_csf     = "true"
+    other_checks = "true"
+  })
+}

--- a/controls/cloudformation.sp
+++ b/controls/cloudformation.sp
@@ -18,8 +18,8 @@ benchmark "cloudformation" {
 }
 
 control "cloudformation_stack_notifications_enabled" {
-  title       = "CloudFormation stacks should have notifications enabled"
-  description = "This control checks whether CloudFormation stacks are associated with an SNS topic to receive notifications when an event occurs."
+  title       = "CloudFormation Stacks should have notifications enabled"
+  description = "This control checks whether CloudFormation Stacks are associated with an SNS topic to receive notifications when an event occurs."
   query       = query.cloudformation_stack_notifications_enabled
 
   tags = merge(local.cloudformation_compliance_common_tags, {

--- a/controls/cloudformation.sp
+++ b/controls/cloudformation.sp
@@ -9,8 +9,7 @@ benchmark "cloudformation" {
   description = "This benchmark provides a set of controls that detect Terraform AWS CloudFormation resources deviating from security best practices."
 
   children = [
-    control.acm_certificate_create_before_destroy_enabled,
-    control.cloudsearch_domain_uses_latest_tls_version
+    control.cloudformation_stack_notifications_enabled
   ]
 
   tags = merge(local.cloudformation_compliance_common_tags, {

--- a/controls/cloudsearch.sp
+++ b/controls/cloudsearch.sp
@@ -1,0 +1,33 @@
+locals {
+  cloudsearch_domain_compliance_common_tags = merge(local.terraform_aws_compliance_common_tags, {
+    service = "AWS/CloudSearchDomain"
+  })
+}
+
+benchmark "cloudsearch_domain" {
+  title       = "CloudSearchDomain"
+  description = "This benchmark provides a set of controls that detect Terraform AWS CloudSearchDomain resources deviating from security best practices."
+
+  children = [
+    control.cloudsearch_domain_enforced_https_enabled,
+    control.cloudsearch_domain_uses_latest_tls_version
+  ]
+
+  tags = merge(local.cloudsearch_domain_compliance_common_tags, {
+    type = "Benchmark"
+  })
+}
+
+control "cloudsearch_domain_enforced_https_enabled" {
+  title       = "CloudSearchDomain should have enforced HTTPS enabled"
+  description = "This control checks whether the CloudSearchDomain has enforced HTTPS enabled."
+  query       = query.cloudsearch_domain_enforced_https_enabled
+  tags        = local.cloudsearch_domain_compliance_common_tags
+}
+
+control "cloudsearch_domain_uses_latest_tls_version" {
+  title       = "CloudSearchDomain should use the latest TLS version"
+  description = "This control checks whether the CloudSearchDomain uses the latest TLS version."
+  query       = query.cloudsearch_domain_uses_latest_tls_version
+  tags        = local.cloudsearch_domain_compliance_common_tags
+}

--- a/controls/cloudsearch.sp
+++ b/controls/cloudsearch.sp
@@ -22,12 +22,14 @@ control "cloudsearch_domain_enforced_https_enabled" {
   title       = "CloudSearchDomain should have enforced HTTPS enabled"
   description = "This control checks whether the CloudSearchDomain has enforced HTTPS enabled."
   query       = query.cloudsearch_domain_enforced_https_enabled
-  tags        = local.cloudsearch_domain_compliance_common_tags
+
+  tags = local.cloudsearch_domain_compliance_common_tags
 }
 
 control "cloudsearch_domain_uses_latest_tls_version" {
   title       = "CloudSearchDomain should use the latest TLS version"
   description = "This control checks whether the CloudSearchDomain uses the latest TLS version."
   query       = query.cloudsearch_domain_uses_latest_tls_version
-  tags        = local.cloudsearch_domain_compliance_common_tags
+
+  tags = local.cloudsearch_domain_compliance_common_tags
 }

--- a/controls/cloudwatch.sp
+++ b/controls/cloudwatch.sp
@@ -11,6 +11,7 @@ benchmark "cloudwatch" {
   children = [
     control.cloudwatch_alarm_action_enabled,
     control.cloudwatch_destination_policy_wildcards,
+    control.cloudwatch_log_group_retention,
     control.cloudwatch_log_group_retention_period_365,
     control.log_group_encryption_at_rest_enabled
   ]
@@ -67,4 +68,12 @@ control "log_group_encryption_at_rest_enabled" {
     rbi_cyber_security = "true"
     soc_2              = "true"
   })
+}
+
+control "cloudwatch_log_group_retention" {
+  title       = "Log group retention period should be set"
+  description = "Ensure that CloudWatch Log Group specifies retention days."
+  query       = query.cloudwatch_log_group_retention
+
+  tags = local.cloudwatch_compliance_common_tags
 }

--- a/controls/codeartifact.sp
+++ b/controls/codeartifact.sp
@@ -21,5 +21,6 @@ control "codeartifact_domain_encrypted_with_kms_cmk" {
   title       = "CodeArtifactDomain should be encrypted with KMS CMK"
   description = "This control checks whether CodeArtifactDomain is encrypted with KMS CMK."
   query       = query.codeartifact_domain_encrypted_with_kms_cmk
-  tags        = local.codeartifact_domain_compliance_common_tags
+
+  tags = local.codeartifact_domain_compliance_common_tags
 }

--- a/controls/codeartifact.sp
+++ b/controls/codeartifact.sp
@@ -1,0 +1,25 @@
+locals {
+  codeartifact_domain_compliance_common_tags = merge(local.terraform_aws_compliance_common_tags, {
+    service = "AWS/CodeArtifactDomain"
+  })
+}
+
+benchmark "codeartifact_domain" {
+  title       = "CodeArtifactDomain"
+  description = "This benchmark provides a set of controls that detect Terraform AWS CodeArtifactDomain resources deviating from security best practices."
+
+  children = [
+    control.codeartifact_domain_encrypted_with_kms_cmk
+  ]
+
+  tags = merge(local.codeartifact_domain_compliance_common_tags, {
+    type = "Benchmark"
+  })
+}
+
+control "codeartifact_domain_encrypted_with_kms_cmk" {
+  title       = "CodeArtifactDomain should be encrypted with KMS CMK"
+  description = "This control checks whether CodeArtifactDomain is encrypted with KMS CMK."
+  query       = query.codeartifact_domain_encrypted_with_kms_cmk
+  tags        = local.codeartifact_domain_compliance_common_tags
+}

--- a/controls/codeartifact.sp
+++ b/controls/codeartifact.sp
@@ -18,8 +18,8 @@ benchmark "codeartifact_domain" {
 }
 
 control "codeartifact_domain_encrypted_with_kms_cmk" {
-  title       = "CodeArtifactDomain should be encrypted with KMS CMK"
-  description = "This control checks whether CodeArtifactDomain is encrypted with KMS CMK."
+  title       = "CodeArtifact Domain should be encrypted with KMS CMK"
+  description = "This control checks whether CodeArtifact Domain is encrypted with KMS CMK."
   query       = query.codeartifact_domain_encrypted_with_kms_cmk
 
   tags = local.codeartifact_domain_compliance_common_tags

--- a/controls/codebuild.sp
+++ b/controls/codebuild.sp
@@ -84,3 +84,11 @@ control "codebuild_project_logging_enabled" {
     nist_csf                               = "true"
   })
 }
+
+control "codebuild_project_privileged_mode_disabled" {
+  title       = "CodeBuild project privileged mode should be disabled"
+  description = "This control checks whether CodeBuild project privileged mode is disabled."
+  query       = query.codebuild_project_privileged_mode_disabled
+
+  tags = local.codebuild_compliance_common_tags
+}

--- a/controls/codebuild.sp
+++ b/controls/codebuild.sp
@@ -9,6 +9,7 @@ benchmark "codebuild" {
   description = "This benchmark provides a set of controls that detect Terraform AWS CodeBuild resources deviating from security best practices."
 
   children = [
+    codebuild_project_privileged_mode_disabled,
     control.codebuild_project_encryption_at_rest_enabled,
     control.codebuild_project_logging_enabled,
     control.codebuild_project_plaintext_env_variables_no_sensitive_aws_values,

--- a/controls/codepipeline.sp
+++ b/controls/codepipeline.sp
@@ -21,5 +21,6 @@ control "codepipeline_artifacts_encrypted_with_kms_cmk" {
   title       = "CodePipeline artifacts encrypted with KMS CMK"
   description = "This control checks whether the CodePipeline artifacts are encrypted."
   query       = query.codepipeline_artifacts_encrypted_with_kms_cmk
-  tags        = local.codepipeline_compliance_common_tags
+
+  tags = local.codepipeline_compliance_common_tags
 }

--- a/controls/codepipeline.sp
+++ b/controls/codepipeline.sp
@@ -18,8 +18,8 @@ benchmark "codepipeline" {
 }
 
 control "codepipeline_artifacts_encrypted_with_kms_cmk" {
-  title       = "CodePipeline artifacts encrypted with KMS CMK"
-  description = "This control checks whether the CodePipeline artifacts are encrypted."
+  title       = "CodePipeline Artifacts encrypted with KMS CMK"
+  description = "This control checks whether the CodePipeline Artifacts are encrypted."
   query       = query.codepipeline_artifacts_encrypted_with_kms_cmk
 
   tags = local.codepipeline_compliance_common_tags

--- a/controls/codepipeline.sp
+++ b/controls/codepipeline.sp
@@ -1,0 +1,25 @@
+locals {
+  codepipeline_compliance_common_tags = merge(local.terraform_aws_compliance_common_tags, {
+    service = "AWS/CodePipeline"
+  })
+}
+
+benchmark "codepipeline" {
+  title       = "CodePipeline"
+  description = "This benchmark provides a set of controls that detect Terraform AWS CodePipeline resources deviating from security best practices."
+
+  children = [
+    control.codepipeline_artifacts_encrypted_with_kms_cmk
+  ]
+
+  tags = merge(local.codepipeline_compliance_common_tags, {
+    type = "Benchmark"
+  })
+}
+
+control "codepipeline_artifacts_encrypted_with_kms_cmk" {
+  title       = "CodePipeline artifacts encrypted with KMS CMK"
+  description = "This control checks whether the CodePipeline artifacts are encrypted."
+  query       = query.codepipeline_artifacts_encrypted_with_kms_cmk
+  tags        = local.codepipeline_compliance_common_tags
+}

--- a/controls/dax.sp
+++ b/controls/dax.sp
@@ -9,7 +9,8 @@ benchmark "dax" {
   description = "This benchmark provides a set of controls that detect Terraform AWS DAX resources deviating from security best practices."
 
   children = [
-    control.dax_cluster_encryption_at_rest_enabled
+    control.dax_cluster_encryption_at_rest_enabled,
+    control.dax_cluster_endpoint_encryption_tls_enabled
   ]
 
   tags = merge(local.dax_compliance_common_tags, {
@@ -27,4 +28,12 @@ control "dax_cluster_encryption_at_rest_enabled" {
     gdpr                      = "true"
     hipaa                     = "true"
   })
+}
+
+control "dax_cluster_endpoint_encryption_tls_enabled" {
+  title       = "DAX clusters endpoint encryption should have TLS enabled"
+  description = "This control checks whether a DAX cluster endpoint encryption has TLS enabled. TLS encrypts the connection between the application and the DAX cluster. Encrypting data in transit protects it from being intercepted by a user not authenticated to AWS. The encryption adds another set of access controls to limit the ability of unauthorized users to access to the data. For example, API permissions are required to decrypt the data before it can be read."
+  query       = query.dax_cluster_endpoint_encryption_tls_enabled
+
+  tags = local.dax_compliance_common_tags
 }

--- a/controls/dms.sp
+++ b/controls/dms.sp
@@ -31,3 +31,35 @@ control "dms_replication_instance_not_publicly_accessible" {
     rbi_cyber_security        = "true"
   })
 }
+
+control "dms_replication_instance_encrypted_with_kms_cmk" {
+  title       = "DMS replication instances should be encrypted with KMS CMK"
+  description = "This control checks whether DMS replication instances are encrypted with customer-managed key."
+  query       = query.dms_replication_instance_encrypted_with_kms_cmk
+
+  tags = local.dms_compliance_common_tags
+}
+
+control "dms_replication_instance_automatic_minor_version_upgrade_enabled" {
+  title       = "DMS replication instances should have automatic minor version upgrade enabled"
+  description = "This control checks whether DMS replication instances have automatic minor version upgrade enabled."
+  query       = query.dms_replication_instance_automatic_minor_version_upgrade_enabled
+
+  tags = local.dms_compliance_common_tags
+}
+
+control "dms_s3_endpoint_encrypted_with_kms_cmk" {
+  title       = "DMS S3 endpoints should be encrypted with KMS CMK"
+  description = "This control checks whether DMS S3 endpoints are encrypted with customer-managed key."
+  query       = query.dms_s3_endpoint_encrypted_with_kms_cmk
+
+  tags = local.dms_compliance_common_tags
+}
+
+control "dms_s3_endpoint_encryption_in_transit_enabled" {
+  title       = "DMS S3 endpoints should be encrypted at transit"
+  description = "This control checks whether DMS S3 endpoints are securely encrypted at transit."
+  query       = query.dms_s3_endpoint_encryption_in_transit_enabled
+
+  tags = local.dms_compliance_common_tags
+}

--- a/controls/dms.sp
+++ b/controls/dms.sp
@@ -9,7 +9,11 @@ benchmark "dms" {
   description = "This benchmark provides a set of controls that detect Terraform AWS DMS resources deviating from security best practices."
 
   children = [
-    control.dms_replication_instance_not_publicly_accessible
+    control.dms_replication_instance_automatic_minor_version_upgrade_enabled,
+    control.dms_replication_instance_encrypted_with_kms_cmk,
+    control.dms_replication_instance_not_publicly_accessible,
+    control.dms_s3_endpoint_encrypted_with_kms_cmk,
+    control.dms_s3_endpoint_encryption_in_transit_enabled
   ]
 
   tags = merge(local.dms_compliance_common_tags, {

--- a/controls/docdb.sp
+++ b/controls/docdb.sp
@@ -12,7 +12,7 @@ benchmark "docdb" {
     control.docdb_cluster_audit_logs_enabled,
     control.docdb_cluster_encrypted_with_kms,
     control.docdb_global_cluster_encrypted,
-    control.docdb_logging_enabled,
+    control.docdb_log_exports_enabled,
     control.docdb_paramater_group_with_logging,
     control.docdb_tls_enabled
   ]
@@ -46,10 +46,10 @@ control "docdb_global_cluster_encrypted" {
   tags = local.docdb_compliance_common_tags
 }
 
-control "docdb_logging_enabled" {
-  title       = "DocDB cluster has logging enabled"
-  description = "This control checks whether DocDB cluster logging is enabled."
-  query       = query.docdb_logging_enabled
+control "docdb_log_exports_enabled" {
+  title       = "DocDB cluster has log export enabled"
+  description = "This control checks whether DocDB cluster log export is enabled."
+  query       = query.docdb_log_exports_enabled
 
   tags = local.docdb_compliance_common_tags
 }

--- a/controls/docdb.sp
+++ b/controls/docdb.sp
@@ -11,10 +11,10 @@ benchmark "docdb" {
   children = [
     control.docdb_cluster_audit_logs_enabled,
     control.docdb_cluster_encrypted_with_kms,
+    control.docdb_cluster_log_exports_enabled,
     control.docdb_global_cluster_encrypted,
-    control.docdb_log_exports_enabled,
-    control.docdb_paramater_group_with_logging,
-    control.docdb_tls_enabled
+    control.docdb_cluster_paramater_group_with_logging,
+    control.docdb_cluster_parameter_group_tls_enabled
   ]
 
   tags = merge(local.docdb_compliance_common_tags, {
@@ -46,26 +46,26 @@ control "docdb_global_cluster_encrypted" {
   tags = local.docdb_compliance_common_tags
 }
 
-control "docdb_log_exports_enabled" {
-  title       = "DocDB cluster has log export enabled"
-  description = "This control checks whether DocDB cluster log export is enabled."
-  query       = query.docdb_log_exports_enabled
+control "docdb_cluster_log_exports_enabled" {
+  title       = "DocDB cluster should have log export enabled"
+  description = "This control checks whether DocDB cluster has log export enabled."
+  query       = query.docdb_cluster_log_exports_enabled
 
   tags = local.docdb_compliance_common_tags
 }
 
-control "docdb_paramater_group_with_logging" {
-  title       = "DocDB has audit logs enabled"
-  description = "This control checks whether DocDB logging is enabled through its parameter group."
-  query       = query.docdb_paramater_group_with_logging
+control "docdb_cluster_paramater_group_with_logging" {
+  title       = "DocDB parameter group should have audit logs enabled"
+  description = "This control checks whether DocDB parameter group has logging enabled."
+  query       = query.docdb_cluster_paramater_group_with_logging
 
   tags = local.docdb_compliance_common_tags
 }
 
-control "docdb_tls_enabled" {
+control "docdb_cluster_parameter_group_tls_enabled" {
   title       = "DocDB TLS should be enabled"
   description = "This control checks whether DocDB TLS is enabled through its parameter group."
-  query       = query.docdb_tls_enabled
+  query       = query.docdb_cluster_parameter_group_tls_enabled
 
   tags = local.docdb_compliance_common_tags
 }

--- a/controls/docdb.sp
+++ b/controls/docdb.sp
@@ -12,8 +12,9 @@ benchmark "docdb" {
     control.docdb_cluster_audit_logs_enabled,
     control.docdb_cluster_encrypted_with_kms,
     control.docdb_global_cluster_encrypted,
+    control.docdb_logging_enabled,
     control.docdb_paramater_group_with_logging,
-    control.docdb_logging_enabled
+    control.docdb_tls_enabled
   ]
 
   tags = merge(local.docdb_compliance_common_tags, {
@@ -45,18 +46,26 @@ control "docdb_global_cluster_encrypted" {
   tags = local.docdb_compliance_common_tags
 }
 
+control "docdb_logging_enabled" {
+  title       = "DocDB cluster has logging enabled"
+  description = "This control checks whether DocDB cluster logging is enabled."
+  query       = query.docdb_logging_enabled
+
+  tags = local.docdb_compliance_common_tags
+}
+
 control "docdb_paramater_group_with_logging" {
   title       = "DocDB has audit logs enabled"
-  description = "This control checks whether DocDB parameter group has audit logs enabled."
+  description = "This control checks whether DocDB logging is enabled through its parameter group."
   query       = query.docdb_paramater_group_with_logging
 
   tags = local.docdb_compliance_common_tags
 }
 
-control "docdb_logging_enabled" {
-  title       = "DocDB has logging enabled"
-  description = "This control checks whether DocDB clsuter logging is enabled."
-  query       = query.docdb_logging_enabled
+control "docdb_tls_enabled" {
+  title       = "DocDB TLS should be enabled"
+  description = "This control checks whether DocDB TLS is enabled through its parameter group."
+  query       = query.docdb_tls_enabled
 
   tags = local.docdb_compliance_common_tags
 }

--- a/controls/docdb.sp
+++ b/controls/docdb.sp
@@ -37,7 +37,7 @@ control "docdb_cluster_encrypted_with_kms" {
 
 control "docdb_paramater_group_with_logging" {
   title       = "DocDB has audit logs enabled"
-  description = "Ensure DocDB pamater group is associated with audit log."
+  description = "This control checks whether DocDB parameter group has audit logs enabled."
   query       = query.docdb_paramater_group_with_logging
 
   tags = local.docdb_compliance_common_tags

--- a/controls/docdb.sp
+++ b/controls/docdb.sp
@@ -12,7 +12,8 @@ benchmark "docdb" {
     control.docdb_cluster_audit_logs_enabled,
     control.docdb_cluster_encrypted_with_kms,
     control.docdb_global_cluster_encrypted,
-    control.docdb_paramater_group_with_logging
+    control.docdb_paramater_group_with_logging,
+    control.docdb_logging_enabled
   ]
 
   tags = merge(local.docdb_compliance_common_tags, {
@@ -48,6 +49,14 @@ control "docdb_paramater_group_with_logging" {
   title       = "DocDB has audit logs enabled"
   description = "This control checks whether DocDB parameter group has audit logs enabled."
   query       = query.docdb_paramater_group_with_logging
+
+  tags = local.docdb_compliance_common_tags
+}
+
+control "docdb_logging_enabled" {
+  title       = "DocDB has logging enabled"
+  description = "This control checks whether DocDB clsuter logging is enabled."
+  query       = query.docdb_logging_enabled
 
   tags = local.docdb_compliance_common_tags
 }

--- a/controls/docdb.sp
+++ b/controls/docdb.sp
@@ -11,6 +11,7 @@ benchmark "docdb" {
   children = [
     control.docdb_cluster_audit_logs_enabled,
     control.docdb_cluster_encrypted_with_kms,
+    control.docdb_global_cluster_encrypted,
     control.docdb_paramater_group_with_logging
   ]
 
@@ -31,6 +32,14 @@ control "docdb_cluster_encrypted_with_kms" {
   title       = "DocDB cluster should be encrypted using KMS"
   description = "Ensure DocDB clusters being created are set to be encrypted at rest using customer-managed CMK."
   query       = query.docdb_cluster_encrypted_with_kms
+
+  tags = local.docdb_compliance_common_tags
+}
+
+control "docdb_global_cluster_encrypted" {
+  title       = "DocDB Global Cluster encryption at rest enabled"
+  description = "This control checks whether DocDB Global Cluster is enabled with encryption at rest (default is unencrypted)."
+  query       = query.docdb_global_cluster_encrypted
 
   tags = local.docdb_compliance_common_tags
 }

--- a/controls/ecs.sp
+++ b/controls/ecs.sp
@@ -10,6 +10,8 @@ benchmark "ecs" {
 
   children = [
     control.ecs_cluster_container_insights_enabled,
+    control.ecs_cluster_logging_enabled,
+    control.ecs_cluster_logging_encrypted_with_kms_cmk,
     control.ecs_task_definition_encryption_in_transit_enabled
   ]
 
@@ -30,6 +32,22 @@ control "ecs_task_definition_encryption_in_transit_enabled" {
   title       = "ECS task definition encryption in transit should be enabled"
   description = "Ensure encryption in transit is enabled for EFS volumes in ECS Task definitions."
   query       = query.ecs_task_definition_encryption_in_transit_enabled
+
+  tags = local.ecs_compliance_common_tags
+}
+
+control "ecs_cluster_logging_enabled" {
+  title       = "ECS cluster logging should be enabled"
+  description = "This control checks whether logging is enabled for the ECS cluster."
+  query       = query.ecs_cluster_logging_enabled
+
+  tags = local.ecs_compliance_common_tags
+}
+
+control "ecs_cluster_logging_encrypted_with_kms_cmk" {
+  title       = "ECS cluster logging should be encrypted with KMS CMK"
+  description = "This control checks whether logging is encrypted with KMS CMK for the ECS cluster."
+  query       = query.ecs_cluster_logging_encrypted_with_kms_cmk
 
   tags = local.ecs_compliance_common_tags
 }

--- a/controls/efs.sp
+++ b/controls/efs.sp
@@ -65,3 +65,11 @@ control "efs_access_point_has_root_directory" {
 
   tags = local.efs_compliance_common_tags
 }
+
+control "efs_file_system_encrypted_with_kms_cmk" {
+  title       = "EFS file system should be encrypted with a KMS CMK"
+  description = "This control checks whether the Elastic File System file system is encrypted with a KMS CMK."
+  query       = query.efs_file_system_encrypted_with_kms_cmk
+
+  tags = local.efs_compliance_common_tags
+}

--- a/controls/efs.sp
+++ b/controls/efs.sp
@@ -12,7 +12,8 @@ benchmark "efs" {
     control.efs_access_point_has_root_directory,
     control.efs_access_point_has_user_identity,
     control.efs_file_system_automatic_backups_enabled,
-    control.efs_file_system_encrypt_data_at_rest
+    control.efs_file_system_encrypt_data_at_rest,
+    control.efs_file_system_encrypted_with_kms_cmk
   ]
 
   tags = merge(local.efs_compliance_common_tags, {

--- a/controls/elasticache.sp
+++ b/controls/elasticache.sp
@@ -9,13 +9,13 @@ benchmark "elasticache" {
   description = "This benchmark provides a set of controls that detect Terraform AWS ElastiCache resources deviating from security best practices."
 
   children = [
-    control.elasticache_redis_cluster_automatic_backup_retention_15_days,
-    control.elasticache_replication_group_encryption_in_transit_enabled_auth_token,
-    control.elasticache_replication_group_encryption_at_rest_enabled,
-    control.elasticache_replication_group_encrypted_with_kms_cmk,
-    control.elasticache_redis_cluster_auto_minor_version_upgrade,
     control.elasticache_cluster_has_subnet_group,
-    control.elasticache_replication_group_encryption_in_transit_enabled
+    control.elasticache_redis_cluster_auto_minor_version_upgrade,
+    control.elasticache_redis_cluster_automatic_backup_retention_15_days,
+    control.elasticache_replication_group_encrypted_with_kms_cmk,
+    control.elasticache_replication_group_encryption_at_rest_enabled,
+    control.elasticache_replication_group_encryption_in_transit_enabled,
+    control.elasticache_replication_group_encryption_in_transit_enabled_auth_token
   ]
 
   tags = merge(local.elasticache_compliance_common_tags, {

--- a/controls/elasticache.sp
+++ b/controls/elasticache.sp
@@ -10,6 +10,11 @@ benchmark "elasticache" {
 
   children = [
     control.elasticache_redis_cluster_automatic_backup_retention_15_days,
+    control.elasticache_replication_group_encryption_in_transit_enabled_auth_token,
+    control.elasticache_replication_group_encryption_at_rest_enabled,
+    control.elasticache_replication_group_encrypted_with_kms_cmk,
+    control.elasticache_redis_cluster_auto_minor_version_upgrade,
+    control.elasticache_cluster_has_subnet_group,
     control.elasticache_replication_group_encryption_in_transit_enabled
   ]
 
@@ -36,6 +41,46 @@ control "elasticache_replication_group_encryption_in_transit_enabled" {
   title       = "ElastiCache replication group should be encrypted at transit"
   description = "Ensure all data stored in the Elasticache Replication Group is securely encrypted at transit"
   query       = query.elasticache_replication_group_encryption_in_transit_enabled
+
+  tags = local.elasticache_compliance_common_tags
+}
+
+control "elasticache_replication_group_encryption_in_transit_enabled_auth_token" {
+  title       = "ElastiCache replication group should be encrypted at transit"
+  description = "This control checks whether all data stored in the Elasticache Replication Group is securely encrypted at transit."
+  query       = query.elasticache_replication_group_encryption_in_transit_enabled_auth_token
+
+  tags = local.elasticache_compliance_common_tags
+}
+
+control "elasticache_replication_group_encryption_at_rest_enabled" {
+  title       = "ElastiCache replication group should be encrypted at rest"
+  description = "This control checks whether all data stored in the Elasticache Replication Group is securely encrypted at rest."
+  query       = query.elasticache_replication_group_encryption_at_rest_enabled
+
+  tags = local.elasticache_compliance_common_tags
+}
+
+control "elasticache_replication_group_encrypted_with_kms_cmk" {
+  title       = "ElastiCache replication group should be encrypted with KMS CMK"
+  description = "This control checks whether all data stored in the Elasticache Replication Group is securely encrypted with KMS CMK."
+  query       = query.elasticache_replication_group_encrypted_with_kms_cmk
+
+  tags = local.elasticache_compliance_common_tags
+}
+
+control "elasticache_redis_cluster_auto_minor_version_upgrade" {
+  title       = "ElastiCache Redis cluster should have auto minor version upgrade enabled"
+  description = "This control checks whether the ElastiCache Redis cluster has auto minor version upgrade enabled."
+  query       = query.elasticache_redis_cluster_auto_minor_version_upgrade
+
+  tags = local.elasticache_compliance_common_tags
+}
+
+control "elasticache_cluster_has_subnet_group" {
+  title       = "ElastiCache cluster should have subnet group"
+  description = "This control checks whether the ElastiCache cluster has subnet group."
+  query       = query.elasticache_cluster_has_subnet_group
 
   tags = local.elasticache_compliance_common_tags
 }

--- a/controls/neptune.sp
+++ b/controls/neptune.sp
@@ -9,8 +9,12 @@ benchmark "neptune" {
   description = "This benchmark provides a set of controls that detect Terraform AWS Neptune resources deviating from security best practices."
 
   children = [
+    control.neptune_cluster_encrypted_with_kms_cmk,
     control.neptune_cluster_encryption_at_rest_enabled,
-    control.neptune_cluster_logging_enabled
+    control.neptune_cluster_instance_publicly_accessible,
+    control.neptune_cluster_logging_enabled,
+    control.neptune_snapshot_encrypted_with_kms_cmk,
+    control.neptune_snapshot_storage_encryption_enabled
   ]
 
   tags = merge(local.neptune_compliance_common_tags, {
@@ -30,6 +34,38 @@ control "neptune_cluster_encryption_at_rest_enabled" {
   title       = "Neptune cluster encryption at rest should be enabled"
   description = "Ensure Neptune clusters being created are set to be encrypted at rest to protect sensitive data."
   query       = query.neptune_cluster_encryption_at_rest_enabled
+
+  tags = local.neptune_compliance_common_tags
+}
+
+control "neptune_cluster_encrypted_with_kms_cmk" {
+  title       = "Neptune cluster should be encrypted with KMS CMK"
+  description = "This control checks whether Neptune clusters are encrypted with a KMS CMK."
+  query       = query.neptune_cluster_encrypted_with_kms_cmk
+
+  tags = local.neptune_compliance_common_tags
+}
+
+control "neptune_cluster_instance_publicly_accessible" {
+  title       = "Neptune cluster instance should not be publicly accessible"
+  description = "This control checks whether Neptune cluster instances are not publicly accessible."
+  query       = query.neptune_cluster_instance_publicly_accessible
+
+  tags = local.neptune_compliance_common_tags
+}
+
+control "neptune_snapshot_storage_encryption_enabled" {
+  title       = "Neptune snapshot storage encryption should be enabled"
+  description = "This control checks whether Neptune snapshot storage encryption is enabled. These snapshots contain sensitive data and should be encrypted at rest."
+  query       = query.neptune_snapshot_storage_encryption_enabled
+
+  tags = local.neptune_compliance_common_tags
+}
+
+control "neptune_snapshot_encrypted_with_kms_cmk" {
+  title       = "Neptune snapshot should be encrypted with KMS CMK"
+  description = "This control checks whether Neptune snapshots are encrypted with a KMS CMK."
+  query       = query.neptune_snapshot_encrypted_with_kms_cmk
 
   tags = local.neptune_compliance_common_tags
 }

--- a/query/acm.sp
+++ b/query/acm.sp
@@ -1,0 +1,42 @@
+
+query "acm_certificate_create_before_destroy_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (lifecycle ->> 'create_before_destroy') = 'true' then 'ok'
+        else 'alarm'
+      end status,
+      name || case
+        when (lifecycle ->> 'create_before_destroy') = 'true' then ' create before destroy enabled'
+        else ' create before destroy disabled'
+      end || '.' reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_acm_certificate';
+  EOQ
+}
+
+query "acm_certificate_transparency_logging_enabled" {
+  sql = <<-EOQ
+      select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'options' ->> 'certificate_transparency_logging_preference')::text = 'ENABLED' then 'ok'
+        else 'alarm'
+      end status,
+      name || case
+        when (arguments -> 'options' ->> 'certificate_transparency_logging_preference')::text = 'ENABLED' then ' certificate transparency logging preference enabled'
+        else ' certificate transparency logging preference disabled'
+      end || '.' reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_acm_certificate';
+  EOQ
+}

--- a/query/appflow.sp
+++ b/query/appflow.sp
@@ -18,3 +18,24 @@ query "appflow_flow_encrypted_with_kms_cmk" {
       type = 'aws_appflow_flow';
   EOQ
 }
+
+query "appflow_connector_profile_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'kms_arn') is null then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments -> 'kms_arn') is null then ' not encrypted with KMS CMK'
+        else ' encrypted with KMS CMK'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_appflow_connector_profile';
+  EOQ
+}

--- a/query/appflow.sp
+++ b/query/appflow.sp
@@ -1,0 +1,20 @@
+query "appflow_flow_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'kms_arn') is null then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments -> 'kms_arn') is null then ' not encrypted with KMS CMK'
+        else ' encrypted with KMS CMK'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_appflow_flow';
+  EOQ
+}

--- a/query/athena.sp
+++ b/query/athena.sp
@@ -40,3 +40,24 @@ query "athena_workgroup_encryption_at_rest_enabled" {
       type = 'aws_athena_workgroup';
   EOQ
 }
+
+query "athena_workgroup_enforce_workgroup_configuration" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'configuration' -> 'enforce_workgroup_configuration')::boolean then 'ok'
+        else 'alarm'
+      end status,
+      name || case
+        when (arguments -> 'configuration' -> 'enforce_workgroup_configuration')::boolean then ' enforce workgroup configuration set'
+        else ' enforce workgroup configuration not set'
+      end || '.' reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_athena_workgroup';
+  EOQ
+}

--- a/query/cloudformation.sp
+++ b/query/cloudformation.sp
@@ -1,0 +1,20 @@
+query "cloudformation_stack_notifications_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments ->> 'notification_arns') is not null then 'ok'
+        else 'alarm'
+      end status,
+      name || case
+        when (arguments ->> 'notification_arns') is not null then ' notifications enabled'
+        else ' notifications disabled'
+      end || '.' reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_cloudformation_stack';    
+  EOQ
+}

--- a/query/cloudsearch.sp
+++ b/query/cloudsearch.sp
@@ -1,0 +1,41 @@
+query "cloudsearch_domain_enforced_https_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'endpoint_options' ->> 'enforce_https')::boolean then 'ok'
+        else 'alarm'
+      end as status,
+      name || case
+        when (arguments -> 'endpoint_options' ->> 'enforce_https')::boolean then ' enforce https enabled'
+        else ' enforce https disabled'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_cloudsearch_domain';    
+  EOQ
+}
+
+query "cloudsearch_domain_uses_latest_tls_version" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then 'ok'
+        else 'alarm'
+      end as status,
+      name || case
+        when (arguments -> 'endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then ' uses latest TLS version'
+        else ' uses old TLS version'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_cloudsearch_domain';    
+  EOQ
+}

--- a/query/cloudwatch.sp
+++ b/query/cloudwatch.sp
@@ -108,3 +108,24 @@ query "log_group_encryption_at_rest_enabled" {
       type = 'aws_cloudwatch_log_group';
   EOQ
 }
+
+query "cloudwatch_log_group_retention" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'retention_in_days') is null then 'alarm'
+        else 'ok'
+      end status,
+      name || case
+        when (arguments -> 'retention_in_days') is null then ' retention period not set'
+        else ' retention period set'
+      end || '.' reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_cloudwatch_log_group';
+  EOQ
+}

--- a/query/codeartifact.sp
+++ b/query/codeartifact.sp
@@ -1,0 +1,20 @@
+query "codeartifact_domain_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments ->> 'encryption_key') is null then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments ->> 'encryption_key') is null then ' not encrypted with KMS CMK'
+        else ' encrypted with KMS CMK'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_codeartifact_domain';    
+  EOQ
+}

--- a/query/codebuild.sp
+++ b/query/codebuild.sp
@@ -143,3 +143,24 @@ query "codebuild_project_logging_enabled" {
       type = 'aws_codebuild_project';
   EOQ
 }
+
+query "codebuild_project_privileged_mode_disabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'environment' ->> 'privileged_mode')::boolean then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments -> 'environment' ->> 'privileged_mode')::boolean then ' has privileged mode enabled'
+        else ' has privileged mode disabled'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_codebuild_project';
+  EOQ
+}

--- a/query/codepipeline.sp
+++ b/query/codepipeline.sp
@@ -1,0 +1,20 @@
+query "codepipeline_artifacts_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'artifact_store' -> 'encryption_key' ->> 'id') is null then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments -> 'artifact_store' -> 'encryption_key' ->> 'id') is null then ' not encrypted with KMS CMK'
+        else ' encrypted with KMS CMK'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_codepipeline';
+  EOQ
+}

--- a/query/dax.sp
+++ b/query/dax.sp
@@ -18,3 +18,24 @@ query "dax_cluster_encryption_at_rest_enabled" {
       type = 'aws_dax_cluster';
   EOQ
 }
+
+query "dax_cluster_endpoint_encryption_tls_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments ->> 'cluster_endpoint_encryption_type') = 'TLS' then 'ok'
+        else 'alarm'
+      end status,
+      name || case
+        when (arguments ->> 'cluster_endpoint_encryption_type') = 'TLS' then ' endpoint encryption tls enabled'
+        else ' endpoint encryption tls disabled'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_dax_cluster';
+  EOQ
+}

--- a/query/dms.sp
+++ b/query/dms.sp
@@ -20,3 +20,86 @@ query "dms_replication_instance_not_publicly_accessible" {
       type = 'aws_dms_replication_instance';
   EOQ
 }
+
+query "dms_replication_instance_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'kms_key_arn') is null then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
+        else ' encrypted with KMS CMK'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_dms_replication_instance';
+  EOQ
+}
+
+query "dms_replication_instance_automatic_minor_version_upgrade_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'auto_minor_version_upgrade')::bool then 'ok'
+        else 'alarm'
+      end as status,
+      name || case
+        when (arguments -> 'auto_minor_version_upgrade')::bool then ' automatic minor version upgrade enabled'
+        else ' automatic minor version upgrade disabled'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_dms_replication_instance';
+  EOQ
+}
+
+query "dms_s3_endpoint_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'kms_key_arn') is null then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
+        else ' encrypted with KMS CMK'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_dms_s3_endpoint';
+  EOQ
+}
+query "dms_s3_endpoint_encryption_in_transit_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'ssl_mode')::text like any (array ['require', 'verify-ca', 'verify-full']) then 'ok'
+        else 'alarm'
+      end as status,
+      name || case
+        when (arguments -> 'ssl_mode')::text like any (array ['require', 'verify-ca', 'verify-full']) then ' encryption in transit enabled'
+        else ' encryption in transit disabled'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_dms_s3_endpoint';
+  EOQ
+}

--- a/query/docdb.sp
+++ b/query/docdb.sp
@@ -124,3 +124,30 @@ query "docdb_logging_enabled" {
       type = 'aws_docdb_cluster';
   EOQ
 }
+
+query "docdb_tls_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when
+         (arguments -> 'parameter'->> 'name') = 'tls'
+         and (arguments -> 'parameter'->> 'value') = 'enabled'
+        then 'ok'
+        else 'alarm'
+      end as status,
+      name || case
+        when
+          (arguments -> 'parameter'->> 'name') = 'tls'
+          and (arguments -> 'parameter'->> 'value') = 'enabled'
+        then ' tls enabled'
+        else ' tls disabled'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_docdb_cluster_parameter_group';
+  EOQ
+}

--- a/query/docdb.sp
+++ b/query/docdb.sp
@@ -74,3 +74,28 @@ query "docdb_paramater_group_with_logging" {
       type = 'aws_docdb_cluster_parameter_group';
   EOQ
 }
+
+query "docdb_global_cluster_encrypted" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when
+          (arguments ->> 'storage_encrypted')::boolean
+        then 'ok'
+        else 'alarm'
+      end as status,
+      name || case
+        when
+          (arguments ->> 'storage_encrypted')::boolean
+        then ' global cluster is encrypted'
+        else ' global cluster is not encrypted'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_docdb_global_cluster';
+  EOQ
+}

--- a/query/docdb.sp
+++ b/query/docdb.sp
@@ -100,7 +100,7 @@ query "docdb_global_cluster_encrypted" {
   EOQ
 }
 
-query "docdb_logging_enabled" {
+query "docdb_log_exports_enabled" {
   sql = <<-EOQ
     select
       type || ' ' || name as resource,
@@ -113,8 +113,8 @@ query "docdb_logging_enabled" {
       name || case
         when
           (arguments -> 'enabled_cloudwatch_logs_exports') is not null
-        then ' logging enabled'
-        else ' logging disabled'
+        then ' cloudwatch log exports enabled'
+        else ' cloudwatch log exports disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}

--- a/query/docdb.sp
+++ b/query/docdb.sp
@@ -48,7 +48,7 @@ query "docdb_cluster_encrypted_with_kms" {
   EOQ
 }
 
-query "docdb_paramater_group_with_logging" {
+query "docdb_cluster_paramater_group_with_logging" {
   sql = <<-EOQ
     select
       type || ' ' || name as resource,
@@ -100,7 +100,7 @@ query "docdb_global_cluster_encrypted" {
   EOQ
 }
 
-query "docdb_log_exports_enabled" {
+query "docdb_cluster_log_exports_enabled" {
   sql = <<-EOQ
     select
       type || ' ' || name as resource,
@@ -125,7 +125,7 @@ query "docdb_log_exports_enabled" {
   EOQ
 }
 
-query "docdb_tls_enabled" {
+query "docdb_cluster_parameter_group_tls_enabled" {
   sql = <<-EOQ
     select
       type || ' ' || name as resource,
@@ -140,8 +140,8 @@ query "docdb_tls_enabled" {
         when
           (arguments -> 'parameter'->> 'name') = 'tls'
           and (arguments -> 'parameter'->> 'value') = 'enabled'
-        then ' tls enabled'
-        else ' tls disabled'
+        then ' TLS enabled'
+        else ' TLS disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}

--- a/query/docdb.sp
+++ b/query/docdb.sp
@@ -88,8 +88,8 @@ query "docdb_global_cluster_encrypted" {
       name || case
         when
           (arguments ->> 'storage_encrypted')::boolean
-        then ' global cluster is encrypted'
-        else ' global cluster is not encrypted'
+        then ' Global Cluster is encrypted'
+        else ' Global Cluster is not encrypted'
       end || '.' as reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}
@@ -97,5 +97,30 @@ query "docdb_global_cluster_encrypted" {
       terraform_resource
     where
       type = 'aws_docdb_global_cluster';
+  EOQ
+}
+
+query "docdb_logging_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when
+         (arguments -> 'enabled_cloudwatch_logs_exports') is not null
+        then 'ok'
+        else 'alarm'
+      end as status,
+      name || case
+        when
+          (arguments -> 'enabled_cloudwatch_logs_exports') is not null
+        then ' logging enabled'
+        else ' logging disabled'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_docdb_cluster';
   EOQ
 }

--- a/query/ecs.sp
+++ b/query/ecs.sp
@@ -43,3 +43,46 @@ query "ecs_task_definition_encryption_in_transit_enabled" {
       type = 'aws_ecs_task_definition';
   EOQ
 }
+
+query "ecs_cluster_logging_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') in ('DEFAULT','OVERRIDE') then 'ok'
+        else 'alarm'
+      end as status,
+      name || case
+        when (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') in ('DEFAULT','OVERRIDE') then ' logging enabled'
+        else ' logging disabled'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_ecs_cluster';
+  EOQ
+}
+
+query "ecs_cluster_logging_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') <> 'NONE' and (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'kms_key_id') is not null and ((arguments -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 'cloud_watch_encryption_enabled')::boolean or (arguments -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 's3_bucket_encryption_enabled')::boolean) then 'ok'
+        else 'alarm'
+      end as status,
+      name || case
+        when (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') <> 'NONE' and (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'kms_key_id') is not null and ((arguments -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 'cloud_watch_encryption_enabled')::boolean or (arguments -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 's3_bucket_encryption_enabled')::boolean) then ' cluster logging encrypted with kms cmk'
+        when (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') = 'NONE' or (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') is null then ' cluster logging disabled'
+        else ' cluster logging not encrypted with kms cmk'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_ecs_cluster';
+  EOQ
+}

--- a/query/efs.sp
+++ b/query/efs.sp
@@ -86,3 +86,24 @@ query "efs_access_point_has_root_directory" {
       type = 'aws_efs_access_point';
   EOQ
 }
+
+query "efs_file_system_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'kms_key_id') is null then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments -> 'kms_key_id') is null then ' not encrypted with KMS CMK'
+        else ' encrypted with KMS CMK'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_efs_file_system';
+  EOQ
+}

--- a/query/elasticache.sp
+++ b/query/elasticache.sp
@@ -41,3 +41,109 @@ query "elasticache_replication_group_encryption_in_transit_enabled" {
   EOQ
 }
 
+query "elasticache_replication_group_encryption_in_transit_enabled_auth_token" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments ->> 'transit_encryption_enabled')::boolean and (arguments ->> 'auth_token') is not null then 'ok'
+        else 'alarm'
+      end status,
+      name || case
+        when (arguments ->> 'transit_encryption_enabled')::boolean and (arguments ->> 'auth_token') is not null then ' encrypted in transit and auth token set'
+        when (arguments ->> 'transit_encryption_enabled')::boolean and (arguments ->> 'auth_token') is null then ' encrypted in transit but auth token not set'
+        when (arguments ->> 'auth_token') is not null then 'not encrypted in transit but auth token set'
+        else ' not encrypted in transit and auth token not set'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_elasticache_replication_group';
+  EOQ
+}
+
+query "elasticache_replication_group_encryption_at_rest_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments ->> 'at_rest_encryption_enabled')::boolean then 'ok'
+        else 'alarm'
+      end status,
+      name || case
+        when (arguments ->> 'at_rest_encryption_enabled')::boolean then ' encrypted at rest'
+        else ' not encrypted at rest'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_elasticache_replication_group';
+  EOQ
+}
+
+query "elasticache_replication_group_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments ->> 'kms_key_id') is not null then 'ok'
+        else 'alarm'
+      end status,
+      name || case
+        when (arguments ->> 'kms_key_id') is not null then ' encrypted with kms cmk'
+        else ' not encrypted with kms cmk'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_elasticache_replication_group';
+  EOQ
+}
+
+query "elasticache_redis_cluster_auto_minor_version_upgrade" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments ->> 'auto_minor_version_upgrade')::boolean then 'ok'
+        else 'alarm'
+      end status,
+      name || case
+        when (arguments ->> 'auto_minor_version_upgrade')::boolean then ' auto minor version upgrade enabled'
+        else ' auto minor version upgrade disabled'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_elasticache_cluster';
+  EOQ
+}
+
+query "elasticache_cluster_has_subnet_group" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments ->> 'subnet_group_name') is not null then 'ok'
+        else 'alarm'
+      end status,
+      name || case
+        when (arguments ->> 'subnet_group_name') is not null then ' subnet group name set'
+        else ' subnet group name not set'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_elasticache_cluster';
+  EOQ  
+}

--- a/query/neptune.sp
+++ b/query/neptune.sp
@@ -39,3 +39,87 @@ query "neptune_cluster_logging_enabled" {
       type = 'aws_neptune_cluster';
   EOQ
 }
+
+query "neptune_cluster_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'kms_key_arn') is null then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
+        else ' encrypted with KMS CMK'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_neptune_cluster';
+  EOQ
+}
+
+query "neptune_cluster_instance_publicly_accessible" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments ->> 'publicly_accessible')::boolean then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments ->> 'publicly_accessible')::boolean then ' publicly accessible'
+        else ' not publicly accessible'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_neptune_cluster_instance';
+  EOQ
+}
+
+query "neptune_snapshot_storage_encryption_enabled" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments ->> 'storage_encrypted')::boolean then 'ok'
+        else 'alarm'
+      end as status,
+      name || case
+        when (arguments ->> 'storage_encrypted')::boolean then ' encrypted at rest'
+        else ' not encrypted at rest'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_neptune_cluster_snapshot';
+  EOQ
+}
+
+query "neptune_snapshot_encrypted_with_kms_cmk" {
+  sql = <<-EOQ
+    select
+      type || ' ' || name as resource,
+      case
+        when (arguments -> 'kms_key_id') is null then 'alarm'
+        else 'ok'
+      end as status,
+      name || case
+        when (arguments -> 'kms_key_id') is null then ' not encrypted with KMS CMK'
+        else ' encrypted with KMS CMK'
+      end || '.' as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      terraform_resource
+    where
+      type = 'aws_neptune_cluster_snapshot';
+  EOQ
+}


### PR DESCRIPTION
1. [x] acm_certificate_create_before_destroy_enabled
2. [x] acm_certificate_transparency_logging_enabled
3. [x] athena_workgroup_enforce_workgroup_configuration
4. [x] elasticache_replication_group_encryption_in_transit_enabled_auth_token
5. [x] elasticache_replication_group_encryption_at_rest_enabled
6. [x] elasticache_replication_group_encrypted_with_kms_cmk
7. [x] elasticache_redis_cluster_auto_minor_version_upgrade
8. [x] elasticache_cluster_has_subnet_group
9. [x] cloudwatch_log_group_retention
10. [x] cloudformation_stack_notifications_enabled
11. [x] cloudsearch_domain_enforced_https_enabled
12. [x] cloudsearch_domain_uses_latest_tls_version
13. [x] codeartifact_domain_encrypted_with_kms_cmk
14. [x] codebuild_project_privileged_mode_disabled
15. [x] codepipeline_artifacts_encrypted_with_kms_cmk
16. [x] dax_cluster_endpoint_encryption_tls_enabled
17. [x] dms_replication_instance_automatic_minor_version_upgrade_enabled
18. [x] dms_replication_instance_encrypted_with_kms_cmk
19. [x] dms_s3_endpoint_encrypted_with_kms_cmk
20. [x] dms_s3_endpoint_encryption_in_transit_enabled
21. [x] ecs_cluster_logging_enabled
22. [x] ecs_cluster_logging_encrypted_with_kms_cmk
23. [x] ecs_task_definition_role_check
24. [x] ecs_service_fargate_latest
25. [x] efs_file_system_encrypted_with_kms_cmk
26. [x] neptune_cluster_encrypted_with_kms_cmk
27. [x] neptune_cluster_instance_publicly_accessible
28. [x] neptune_snapshot_storage_encryption_enabled
29. [x] neptune_snapshot_encrypted_with_kms_cmk
30. [x] appflow_flow_encrypted_with_kms_cmk
31. [x] appflow_connector_profile_encrypted_with_kms_cmk
32. [x] docdb_global_cluster_encrypted
33. [x] docdb_cluster_paramater_group_logging_enabled
34. [x] docdb_cluster_log_exports_enabled
35. [x] docdb_cluster_parameter_group_tls_enabled