### PR TITLE
Update controls to use the `attributes_std` column from table `terraform_resource` instead of `arguments` for better support for terraform state files. Closes #89

### DIFF
--- a/controls/globalaccelerator.sp
+++ b/controls/globalaccelerator.sp
@@ -18,7 +18,7 @@ benchmark "globalaccelerator" {
 }
 
 control "globalaccelerator_flow_logs_enabled" {
-  title       = "Global Accelerator  flow logs should be enabled"
+  title       = "Global Accelerator flow logs should be enabled"
   description = "Ensure Global Accelerator accelerator has flow logs enabled"
   query       = query.globalaccelerator_flow_logs_enabled
 

--- a/mod.sp
+++ b/mod.sp
@@ -69,7 +69,7 @@ mod "terraform_aws_compliance" {
 
   requires {
     plugin "terraform" {
-      version = "0.9.0"
+      version = "0.10.0"
     }
   }
 }

--- a/mod.sp
+++ b/mod.sp
@@ -69,7 +69,7 @@ mod "terraform_aws_compliance" {
 
   requires {
     plugin "terraform" {
-      version = "0.0.5"
+      version = "0.9.0"
     }
   }
 }

--- a/mod.sp
+++ b/mod.sp
@@ -38,7 +38,7 @@ locals {
   # Local internal variable to build the SQL select clause for tag
   # dimensions. Do not edit directly.
   tag_dimensions_qualifier_sql = <<-EOQ
-  %{~for dim in var.tag_dimensions},  __QUALIFIER__arguments -> 'tags' ->> '${dim}' as "${replace(dim, "\"", "\"\"")}"%{endfor~}
+  %{~for dim in var.tag_dimensions},  __QUALIFIER__attributes_std -> 'tags' ->> '${dim}' as "${replace(dim, "\"", "\"\"")}"%{endfor~}
   EOQ
 
 }

--- a/query/acm.sp
+++ b/query/acm.sp
@@ -2,12 +2,12 @@
 query "acm_certificate_create_before_destroy_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when (lifecycle ->> 'create_before_destroy') = 'true' then 'ok'
         else 'alarm'
       end status,
-      name || case
+      address || case
         when (lifecycle ->> 'create_before_destroy') = 'true' then ' create before destroy enabled'
         else ' create before destroy disabled'
       end || '.' reason
@@ -23,13 +23,13 @@ query "acm_certificate_create_before_destroy_enabled" {
 query "acm_certificate_transparency_logging_enabled" {
   sql = <<-EOQ
       select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'options' ->> 'certificate_transparency_logging_preference')::text = 'ENABLED' then 'ok'
+        when (attributes_std -> 'options' ->> 'certificate_transparency_logging_preference')::text = 'ENABLED' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'options' ->> 'certificate_transparency_logging_preference')::text = 'ENABLED' then ' certificate transparency logging preference enabled'
+      address || case
+        when (attributes_std -> 'options' ->> 'certificate_transparency_logging_preference')::text = 'ENABLED' then ' certificate transparency logging preference enabled'
         else ' certificate transparency logging preference disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/acm.sp
+++ b/query/acm.sp
@@ -7,7 +7,7 @@ query "acm_certificate_create_before_destroy_enabled" {
         when (lifecycle ->> 'create_before_destroy') = 'true' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (lifecycle ->> 'create_before_destroy') = 'true' then ' create before destroy enabled'
         else ' create before destroy disabled'
       end || '.' reason
@@ -28,7 +28,7 @@ query "acm_certificate_transparency_logging_enabled" {
         when (attributes_std -> 'options' ->> 'certificate_transparency_logging_preference')::text = 'ENABLED' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'options' ->> 'certificate_transparency_logging_preference')::text = 'ENABLED' then ' certificate transparency logging preference enabled'
         else ' certificate transparency logging preference disabled'
       end || '.' reason

--- a/query/apigateway.sp
+++ b/query/apigateway.sp
@@ -6,7 +6,7 @@ query "apigateway_rest_api_stage_use_ssl_certificate" {
         when (attributes_std -> 'client_certificate_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'client_certificate_id') is null then ' does not use SSL certificate'
         else ' uses SSL certificate'
       end || '.' reason
@@ -27,7 +27,7 @@ query "apigateway_rest_api_stage_xray_tracing_enabled" {
         when (attributes_std ->> 'tracing_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'tracing_enabled')::boolean then ' X-Ray tracing enabled'
         else ' X-Ray tracing disabled'
       end || '.' reason
@@ -70,7 +70,7 @@ query "apigateway_stage_cache_encryption_at_rest_enabled" {
       when (caching_enabled)::boolean and (cache_data_encrypted)::boolean then 'ok'
       else 'alarm'
     end status,
-    address || case
+    split_part(address, '.', 2) || case
       when (caching_enabled)::boolean and (cache_data_encrypted)::boolean then ' API cache and encryption enabled'
       else ' API cache and encryption not enabled'
     end || '.' reason
@@ -145,7 +145,7 @@ query "apigateway_stage_logging_enabled" {
       when log_level is null or log_level = 'OFF' then 'alarm'
       else 'ok'
     end status,
-    address || case
+    split_part(address, '.', 2) || case
       when log_level is null or log_level = 'OFF' then ' logging disabled'
       else ' logging enabled'
     end || '.' reason
@@ -164,7 +164,7 @@ query "apigateway_rest_api_create_before_destroy_enabled" {
         when (lifecycle ->> 'create_before_destroy') = 'true' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (lifecycle ->> 'create_before_destroy') = 'true' then ' create before destroy enabled'
         else ' create before destroy disabled'
       end || '.' reason
@@ -185,7 +185,7 @@ query "apigateway_deployment_create_before_destroy_enabled" {
         when (lifecycle ->> 'create_before_destroy') = 'true' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (lifecycle ->> 'create_before_destroy') = 'true' then ' create before destroy enabled'
         else ' create before destroy disabled'
       end || '.' reason
@@ -204,7 +204,7 @@ query "apigateway_method_settings_cache_enabled" {
         when (attributes_std -> 'settings' ->> 'caching_enabled') = 'true' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'settings' ->> 'caching_enabled') = 'true' then ' caching enabled'
         else ' caching disabled'
       end || '.' reason
@@ -225,7 +225,7 @@ query "apigateway_method_settings_cache_encryption_enabled" {
         when (attributes_std -> 'settings' ->> 'cache_data_encrypted') = 'true' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'settings' ->> 'cache_data_encrypted') = 'true' then ' cache encryption enabled'
         else ' cache encryption disabled'
       end || '.' reason
@@ -246,7 +246,7 @@ query "apigateway_method_settings_data_trace_enabled" {
         when (attributes_std -> 'settings' ->> 'data_trace_enabled') = 'true' then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'settings' ->> 'data_trace_enabled') = 'true' then ' data trace enabled'
         else ' data trace disabled'
       end || '.' reason
@@ -267,7 +267,7 @@ query "apigatewayv2_route_set_authorization_type" {
         when (attributes_std ->> 'authorization_type') in ('AWS_IAM', 'CUSTOM', 'JWT') then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'authorization_type') in ('AWS_IAM', 'CUSTOM', 'JWT') then ' defines an authorization type'
         else ' does not define an authorization type'
       end || '.' reason
@@ -289,7 +289,7 @@ query "apigateway_method_restricts_open_access" {
         when (attributes_std ->> 'http_method') != 'OPTIONS' and (attributes_std ->> 'authorization') = 'NONE' and (attributes_std ->> 'api_key_required') = 'false' then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'http_method') != 'OPTIONS' and (attributes_std ->> 'authorization') = 'NONE' and (attributes_std ->> 'api_key_required') is null then ' does not restrict open access'
         when (attributes_std ->> 'http_method') != 'OPTIONS' and (attributes_std ->> 'authorization') = 'NONE' and (attributes_std ->> 'api_key_required') = 'false' then ' does not restrict open access'
         else ' is restrictive with http_method as ' || (attributes_std ->> 'http_method') || ', authorization as ' || (attributes_std ->> 'authorization') || ' and api_key_required as ' || (attributes_std ->> 'api_key_required')
@@ -311,7 +311,7 @@ query "apigateway_domain_name_use_latest_tls" {
         when (attributes_std ->> 'security_policy') is null or (attributes_std ->> 'security_policy') = 'TLS_1_2' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'security_policy') is null or (attributes_std ->> 'security_policy') = 'TLS_1_2' then ' uses latest TLS security policy'
         else ' does not use latest TLS security policy'
       end || '.' reason

--- a/query/appflow.sp
+++ b/query/appflow.sp
@@ -6,7 +6,7 @@ query "appflow_flow_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "appflow_connector_profile_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason

--- a/query/appflow.sp
+++ b/query/appflow.sp
@@ -1,13 +1,13 @@
 query "appflow_flow_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_arn') is null then 'alarm'
+        when (attributes_std -> 'kms_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kms_arn') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "appflow_flow_encrypted_with_kms_cmk" {
 query "appflow_connector_profile_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_arn') is null then 'alarm'
+        when (attributes_std -> 'kms_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kms_arn') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/appsync.sp
+++ b/query/appsync.sp
@@ -6,7 +6,7 @@ query "appsync_graphql_api_field_level_logs_enabled" {
         when (attributes_std -> 'log_config' ->> 'field_log_level') in ('ALL','ERROR') then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'log_config' ->> 'field_log_level') in ('ALL','ERROR') then ' field level logs enabled'
         else ' field level logs disabled'
       end || '.' reason
@@ -27,7 +27,7 @@ query "appsync_graphql_api_cloudwatch_logs_enabled" {
         when (attributes_std -> 'log_config' ->> 'cloudwatch_logs_role_arn') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'log_config' ->> 'cloudwatch_logs_role_arn') is not null then ' cloudwatch logs enabled'
         else ' cloudwatch logs disabled'
       end || '.' reason
@@ -48,7 +48,7 @@ query "appsync_api_cache_encryption_at_rest_enabled" {
         when (attributes_std ->> 'at_rest_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'at_rest_encryption_enabled')::boolean then ' encryption at rest enabled'
         else ' encryption at rest disabled'
       end || '.' reason
@@ -69,7 +69,7 @@ query "appsync_api_cache_encryption_in_transit_enabled" {
         when (attributes_std ->> 'transit_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'transit_encryption_enabled')::boolean then ' encryption in transit enabled'
         else ' encryption in transit disabled'
       end || '.' reason

--- a/query/appsync.sp
+++ b/query/appsync.sp
@@ -1,13 +1,13 @@
 query "appsync_graphql_api_field_level_logs_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'log_config' ->> 'field_log_level') in ('ALL','ERROR') then 'ok'
+        when (attributes_std -> 'log_config' ->> 'field_log_level') in ('ALL','ERROR') then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'log_config' ->> 'field_log_level') in ('ALL','ERROR') then ' field level logs enabled'
+      address || case
+        when (attributes_std -> 'log_config' ->> 'field_log_level') in ('ALL','ERROR') then ' field level logs enabled'
         else ' field level logs disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "appsync_graphql_api_field_level_logs_enabled" {
 query "appsync_graphql_api_cloudwatch_logs_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'log_config' ->> 'cloudwatch_logs_role_arn') is not null then 'ok'
+        when (attributes_std -> 'log_config' ->> 'cloudwatch_logs_role_arn') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'log_config' ->> 'cloudwatch_logs_role_arn') is not null then ' cloudwatch logs enabled'
+      address || case
+        when (attributes_std -> 'log_config' ->> 'cloudwatch_logs_role_arn') is not null then ' cloudwatch logs enabled'
         else ' cloudwatch logs disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -43,13 +43,13 @@ query "appsync_graphql_api_cloudwatch_logs_enabled" {
 query "appsync_api_cache_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'at_rest_encryption_enabled')::boolean then 'ok'
+        when (attributes_std ->> 'at_rest_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'at_rest_encryption_enabled')::boolean then ' encryption at rest enabled'
+      address || case
+        when (attributes_std ->> 'at_rest_encryption_enabled')::boolean then ' encryption at rest enabled'
         else ' encryption at rest disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -64,13 +64,13 @@ query "appsync_api_cache_encryption_at_rest_enabled" {
 query "appsync_api_cache_encryption_in_transit_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'transit_encryption_enabled')::boolean then 'ok'
+        when (attributes_std ->> 'transit_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'transit_encryption_enabled')::boolean then ' encryption in transit enabled'
+      address || case
+        when (attributes_std ->> 'transit_encryption_enabled')::boolean then ' encryption in transit enabled'
         else ' encryption in transit disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/athena.sp
+++ b/query/athena.sp
@@ -6,7 +6,7 @@ query "athena_database_encryption_at_rest_enabled" {
         when (attributes_std -> 'encryption_configuration') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encryption_configuration') is not null then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' reason
@@ -27,7 +27,7 @@ query "athena_workgroup_encryption_at_rest_enabled" {
         then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'configuration' -> 'result_configuration' -> 'encryption_configuration') is not null
         then ' encrypted at rest'
         else ' not encrypted at rest'
@@ -49,7 +49,7 @@ query "athena_workgroup_enforce_workgroup_configuration" {
         when (attributes_std -> 'configuration' -> 'enforce_workgroup_configuration')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'configuration' -> 'enforce_workgroup_configuration')::boolean then ' enforce workgroup configuration set'
         else ' enforce workgroup configuration not set'
       end || '.' reason

--- a/query/athena.sp
+++ b/query/athena.sp
@@ -1,13 +1,13 @@
 query "athena_database_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encryption_configuration') is not null then 'ok'
+        when (attributes_std -> 'encryption_configuration') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'encryption_configuration') is not null then ' encrypted at rest'
+      address || case
+        when (attributes_std -> 'encryption_configuration') is not null then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' reason
       ${local.common_dimensions_sql}
@@ -21,14 +21,14 @@ query "athena_database_encryption_at_rest_enabled" {
 query "athena_workgroup_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'configuration' -> 'result_configuration' -> 'encryption_configuration') is not null
+        when (attributes_std -> 'configuration' -> 'result_configuration' -> 'encryption_configuration') is not null
         then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'configuration' -> 'result_configuration' -> 'encryption_configuration') is not null
+      address || case
+        when (attributes_std -> 'configuration' -> 'result_configuration' -> 'encryption_configuration') is not null
         then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' reason
@@ -44,13 +44,13 @@ query "athena_workgroup_encryption_at_rest_enabled" {
 query "athena_workgroup_enforce_workgroup_configuration" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'configuration' -> 'enforce_workgroup_configuration')::boolean then 'ok'
+        when (attributes_std -> 'configuration' -> 'enforce_workgroup_configuration')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'configuration' -> 'enforce_workgroup_configuration')::boolean then ' enforce workgroup configuration set'
+      address || case
+        when (attributes_std -> 'configuration' -> 'enforce_workgroup_configuration')::boolean then ' enforce workgroup configuration set'
         else ' enforce workgroup configuration not set'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/autoscaling.sp
+++ b/query/autoscaling.sp
@@ -1,15 +1,15 @@
 query "autoscaling_group_with_lb_use_health_check" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'load_balancers') is null and (arguments -> 'target_group_arns') is null then 'alarm'
-        when (arguments ->> 'health_check_type') <> 'ELB' then 'alarm'
+        when (attributes_std -> 'load_balancers') is null and (attributes_std -> 'target_group_arns') is null then 'alarm'
+        when (attributes_std ->> 'health_check_type') <> 'ELB' then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'load_balancers') is null and (arguments -> 'target_group_arns') is null then ' not associated with a load balancer'
-        when (arguments ->> 'health_check_type') <> 'ELB' then ' does not use ELB health check'
+      address || case
+        when (attributes_std -> 'load_balancers') is null and (attributes_std -> 'target_group_arns') is null then ' not associated with a load balancer'
+        when (attributes_std ->> 'health_check_type') <> 'ELB' then ' does not use ELB health check'
         else ' uses ELB health check'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -24,13 +24,13 @@ query "autoscaling_group_with_lb_use_health_check" {
 query "autoscaling_launch_config_public_ip_disabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'associate_public_ip_address')::boolean then 'alarm'
+        when (attributes_std -> 'associate_public_ip_address')::boolean then 'alarm'
         else 'ok'
       end status,
-      name || case
-      when (arguments -> 'associate_public_ip_address')::boolean then ' public IP enabled'
+      address || case
+      when (attributes_std -> 'associate_public_ip_address')::boolean then ' public IP enabled'
         else ' public IP disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -45,13 +45,13 @@ query "autoscaling_launch_config_public_ip_disabled" {
 query "autoscaling_group_uses_launch_template" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'launch_template') is null then 'alarm'
+        when (attributes_std -> 'launch_template') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'launch_template') is null then ' not using launch template'
+      address || case
+        when (attributes_std -> 'launch_template') is null then ' not using launch template'
         else ' using launch template'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -66,13 +66,13 @@ query "autoscaling_group_uses_launch_template" {
 query "autoscaling_group_tagging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'tag') is not null or (arguments -> 'tags') is not null then 'ok'
+        when (attributes_std -> 'tag') is not null or (attributes_std -> 'tags') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'tag') is not null or (arguments -> 'tags') is not null then ' tagging enabled'
+      address || case
+        when (attributes_std -> 'tag') is not null or (attributes_std -> 'tags') is not null then ' tagging enabled'
         else ' tagging disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/autoscaling.sp
+++ b/query/autoscaling.sp
@@ -7,7 +7,7 @@ query "autoscaling_group_with_lb_use_health_check" {
         when (attributes_std ->> 'health_check_type') <> 'ELB' then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'load_balancers') is null and (attributes_std -> 'target_group_arns') is null then ' not associated with a load balancer'
         when (attributes_std ->> 'health_check_type') <> 'ELB' then ' does not use ELB health check'
         else ' uses ELB health check'
@@ -29,7 +29,7 @@ query "autoscaling_launch_config_public_ip_disabled" {
         when (attributes_std -> 'associate_public_ip_address')::boolean then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
       when (attributes_std -> 'associate_public_ip_address')::boolean then ' public IP enabled'
         else ' public IP disabled'
       end || '.' reason
@@ -50,7 +50,7 @@ query "autoscaling_group_uses_launch_template" {
         when (attributes_std -> 'launch_template') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'launch_template') is null then ' not using launch template'
         else ' using launch template'
       end || '.' reason
@@ -71,7 +71,7 @@ query "autoscaling_group_tagging_enabled" {
         when (attributes_std -> 'tag') is not null or (attributes_std -> 'tags') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'tag') is not null or (attributes_std -> 'tags') is not null then ' tagging enabled'
         else ' tagging disabled'
       end || '.' reason

--- a/query/backup.sp
+++ b/query/backup.sp
@@ -1,13 +1,13 @@
 query "backup_vault_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_arn') is null then 'alarm'
+        when (attributes_std -> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'kms_key_arn') is null then ' encryption at rest disabled'
+      address || case
+        when (attributes_std -> 'kms_key_arn') is null then ' encryption at rest disabled'
         else ' encryption at rest enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,17 +22,17 @@ query "backup_vault_encryption_at_rest_enabled" {
 query "backup_plan_min_retention_35_days" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'rule') is null then 'alarm'
-        when (arguments -> 'rule' -> 'lifecycle') is null then 'ok'
-        when (arguments -> 'rule' -> 'lifecycle' ->> 'delete_after')::int >=35 then 'ok'
+        when (attributes_std -> 'rule') is null then 'alarm'
+        when (attributes_std -> 'rule' -> 'lifecycle') is null then 'ok'
+        when (attributes_std -> 'rule' -> 'lifecycle' ->> 'delete_after')::int >=35 then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'rule') is null then ' retention period not set'
-        when (arguments -> 'rule' -> 'lifecycle') is null then ' retention period set to never expire'
-        else ' retention period set to ' || (arguments -> 'rule' -> 'lifecycle' ->> 'delete_after')::int
+      address || case
+        when (attributes_std -> 'rule') is null then ' retention period not set'
+        when (attributes_std -> 'rule' -> 'lifecycle') is null then ' retention period set to never expire'
+        else ' retention period set to ' || (attributes_std -> 'rule' -> 'lifecycle' ->> 'delete_after')::int
       end || '.' reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}

--- a/query/backup.sp
+++ b/query/backup.sp
@@ -6,7 +6,7 @@ query "backup_vault_encryption_at_rest_enabled" {
         when (attributes_std -> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_arn') is null then ' encryption at rest disabled'
         else ' encryption at rest enabled'
       end || '.' reason
@@ -29,7 +29,7 @@ query "backup_plan_min_retention_35_days" {
         when (attributes_std -> 'rule' -> 'lifecycle' ->> 'delete_after')::int >=35 then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'rule') is null then ' retention period not set'
         when (attributes_std -> 'rule' -> 'lifecycle') is null then ' retention period set to never expire'
         else ' retention period set to ' || (attributes_std -> 'rule' -> 'lifecycle' ->> 'delete_after')::int

--- a/query/cloudformation.sp
+++ b/query/cloudformation.sp
@@ -1,13 +1,13 @@
 query "cloudformation_stack_notifications_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'notification_arns') is not null then 'ok'
+        when (attributes_std ->> 'notification_arns') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'notification_arns') is not null then ' notifications enabled'
+      address || case
+        when (attributes_std ->> 'notification_arns') is not null then ' notifications enabled'
         else ' notifications disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/cloudformation.sp
+++ b/query/cloudformation.sp
@@ -15,6 +15,6 @@ query "cloudformation_stack_notifications_enabled" {
     from
       terraform_resource
     where
-      type = 'aws_cloudformation_stack';    
+      type = 'aws_cloudformation_stack';
   EOQ
 }

--- a/query/cloudformation.sp
+++ b/query/cloudformation.sp
@@ -6,7 +6,7 @@ query "cloudformation_stack_notifications_enabled" {
         when (attributes_std ->> 'notification_arns') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'notification_arns') is not null then ' notifications enabled'
         else ' notifications disabled'
       end || '.' reason

--- a/query/cloudfront.sp
+++ b/query/cloudfront.sp
@@ -6,7 +6,7 @@ query "cloudfront_distribution_configured_with_origin_failover" {
         when (attributes_std -> 'origin_group' -> 'member') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'origin_group' -> 'member' ) is not null then ' origin group is configured'
         else ' origin group not configured'
       end || '.' reason
@@ -27,7 +27,7 @@ query "cloudfront_distribution_default_root_object_configured" {
         when (attributes_std -> 'default_root_object') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'default_root_object') is not null then ' default root object configured'
         else ' default root object not configured'
       end || '.' reason
@@ -50,7 +50,7 @@ query "cloudfront_distribution_encryption_in_transit_enabled" {
       where type = 'aws_cloudfront_distribution'
     ), data as (
       select
-        distinct name
+        distinct address
       from
         cloudfront_distribution,
         jsonb_array_elements(
@@ -62,20 +62,20 @@ query "cloudfront_distribution_encryption_in_transit_enabled" {
         cb ->> 'ViewerProtocolPolicy' = 'allow-all'
   )
   select
-    type || ' ' || b.name as resource,
+    b.address as resource,
     case
-      when d.name is not null or (attributes_std -> 'default_cache_behavior' ->> 'ViewerProtocolPolicy' = 'allow-all') then 'alarm'
+      when d.address is not null or (attributes_std -> 'default_cache_behavior' ->> 'ViewerProtocolPolicy' = 'allow-all') then 'alarm'
       else 'ok'
     end status,
-    case
-      when d.name is not null or (attributes_std -> 'default_cache_behavior' ->> 'ViewerProtocolPolicy' = 'allow-all') then ' data not encrypted in transit'
+    split_part(b.address, '.', 2) || case
+      when d.address is not null or (attributes_std -> 'default_cache_behavior' ->> 'ViewerProtocolPolicy' = 'allow-all') then ' data not encrypted in transit'
       else ' data encrypted in transit'
     end || '.' reason
     ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "b.")}
     ${local.common_dimensions_sql}
   from
     cloudfront_distribution as b
-    left join data as d on b.name = d.name;
+    left join data as d on b.address = d.address;
   EOQ
 }
 
@@ -87,7 +87,7 @@ query "cloudfront_distribution_logging_enabled" {
         when (attributes_std -> 'logging_config') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'logging_config') is not null then ' logging enabled'
         else ' logging disabled'
       end || '.' reason
@@ -111,7 +111,7 @@ query "cloudfront_distribution_origin_access_identity_enabled" {
         type = 'aws_cloudfront_distribution'
     ), origin_type as (
         select
-          distinct name
+          distinct address
         from
           cloudfront_distribution,
           jsonb_array_elements(
@@ -121,11 +121,11 @@ query "cloudfront_distribution_origin_access_identity_enabled" {
             ) as o
         where
           (o ->> 'domain_name' ) like '%aws_s3_bucket%'
-        group by name
+        group by address
     ),origins as (
         select
           count(*),
-          name
+          address
         from
           cloudfront_distribution,
           jsonb_array_elements(
@@ -139,32 +139,32 @@ query "cloudfront_distribution_origin_access_identity_enabled" {
           (o -> 's3_origin_config' ->> 'origin_access_identity') = ''
           or (o -> 's3_origin_config' ) is null
           )
-        group by name
+        group by address
     )
     select
-      type || ' ' || a.name as resource,
+      a.address as resource,
       case
         when (attributes_std -> 'origin') is null then 'alarm'
         when (attributes_std -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (( not((attributes_std -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '')) and (attributes_std -> 'origin' -> 's3_origin_config' -> 'origin_access_identity') is not null) then 'ok'
         when (attributes_std -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (((attributes_std -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '') or ((attributes_std -> 'origin' -> 's3_origin_config') is null)) then 'alarm'
-        when b.name is not null then 'alarm'
-        when (t.name is null ) and ((attributes_std -> 'origin' ->> 'domain_name') not like '%aws_s3_bucket%') then 'skip'
+        when b.address is not null then 'alarm'
+        when (t.address is null ) and ((attributes_std -> 'origin' ->> 'domain_name') not like '%aws_s3_bucket%') then 'skip'
         else 'ok'
       end as status,
-      a.address || case
+      split_part(a.address, '.', 2) || case
         when (attributes_std -> 'origin') is null then ' origins not defined'
         when (attributes_std -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (( not((attributes_std -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '')) and (attributes_std -> 'origin' -> 's3_origin_config' -> 'origin_access_identity') is not null) then ' origin access identity configured'
         when (attributes_std -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (((attributes_std -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '') or ((attributes_std -> 'origin' -> 's3_origin_config') is null)) then ' origin access identity not configured'
-        when b.name is not null then ' origin access identity not configured'
-        when (t.name is null ) and ((attributes_std -> 'origin' ->> 'domain_name') not like '%aws_s3_bucket%') then ' origin type is not S3'
+        when b.address is not null then ' origin access identity not configured'
+        when (t.address is null ) and ((attributes_std -> 'origin' ->> 'domain_name') not like '%aws_s3_bucket%') then ' origin type is not S3'
         else ' origin access identity configured'
       end || '.' reason
       ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "a.")}
       ${local.common_dimensions_sql}
     from
       cloudfront_distribution as a
-      left join origin_type as t on a.name = t.name
-      left join origins as b on a.name = b.name;
+      left join origin_type as t on a.address = t.address
+      left join origins as b on a.address = b.address;
   EOQ
 }
 
@@ -176,7 +176,7 @@ query "cloudfront_distribution_waf_enabled" {
         when (attributes_std -> 'web_acl_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'web_acl_id') is not null then ' associated with WAF'
         else ' not associated with WAF'
       end || '.' reason
@@ -197,7 +197,7 @@ query "cloudfront_protocol_version_is_low" {
         when (attributes_std -> 'viewer_certificate' ->> 'minimum_protocol_version')::text = 'TLSv1.2_2019' then 'ok'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'viewer_certificate' ->> 'minimum_protocol_version')::text = 'TLSv1.2_2019' then ' minimum protocol version is set to TLSv1.2_2019'
         else ' minimum protocol version is not set to TLSv1.2_2019'
       end || '.' as reason
@@ -222,7 +222,7 @@ query "cloudfront_response_header_use_strict_transport_policy_setting" {
         then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'access_control_max_age_sec')::integer = 31536000
         and (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'include_subdomains')::boolean
         and (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'preload')::boolean
@@ -246,7 +246,7 @@ query "cloudfront_distribution_enabled" {
         when (attributes_std ->> 'enabled')::boolean then 'ok'
         else 'info'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when(attributes_std ->> 'enabled')::boolean then ' is enabled'
         else ' is disabled'
       end || '.' as reason

--- a/query/cloudfront.sp
+++ b/query/cloudfront.sp
@@ -1,13 +1,13 @@
 query "cloudfront_distribution_configured_with_origin_failover" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'origin_group' -> 'member') is not null then 'ok'
+        when (attributes_std -> 'origin_group' -> 'member') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'origin_group' -> 'member' ) is not null then ' origin group is configured'
+      address || case
+        when (attributes_std -> 'origin_group' -> 'member' ) is not null then ' origin group is configured'
         else ' origin group not configured'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "cloudfront_distribution_configured_with_origin_failover" {
 query "cloudfront_distribution_default_root_object_configured" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'default_root_object') is not null then 'ok'
+        when (attributes_std -> 'default_root_object') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'default_root_object') is not null then ' default root object configured'
+      address || case
+        when (attributes_std -> 'default_root_object') is not null then ' default root object configured'
         else ' default root object not configured'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -54,8 +54,8 @@ query "cloudfront_distribution_encryption_in_transit_enabled" {
       from
         cloudfront_distribution,
         jsonb_array_elements(
-        case jsonb_typeof(arguments -> 'ordered_cache_behavior' -> 'Items')
-          when 'array' then (arguments -> 'ordered_cache_behavior' -> 'Items')
+        case jsonb_typeof(attributes_std -> 'ordered_cache_behavior' -> 'Items')
+          when 'array' then (attributes_std -> 'ordered_cache_behavior' -> 'Items')
           else null end
         ) as cb
       where
@@ -64,11 +64,11 @@ query "cloudfront_distribution_encryption_in_transit_enabled" {
   select
     type || ' ' || b.name as resource,
     case
-      when d.name is not null or (arguments -> 'default_cache_behavior' ->> 'ViewerProtocolPolicy' = 'allow-all') then 'alarm'
+      when d.name is not null or (attributes_std -> 'default_cache_behavior' ->> 'ViewerProtocolPolicy' = 'allow-all') then 'alarm'
       else 'ok'
     end status,
     case
-      when d.name is not null or (arguments -> 'default_cache_behavior' ->> 'ViewerProtocolPolicy' = 'allow-all') then ' data not encrypted in transit'
+      when d.name is not null or (attributes_std -> 'default_cache_behavior' ->> 'ViewerProtocolPolicy' = 'allow-all') then ' data not encrypted in transit'
       else ' data encrypted in transit'
     end || '.' reason
     ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "b.")}
@@ -82,13 +82,13 @@ query "cloudfront_distribution_encryption_in_transit_enabled" {
 query "cloudfront_distribution_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logging_config') is not null then 'ok'
+        when (attributes_std -> 'logging_config') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'logging_config') is not null then ' logging enabled'
+      address || case
+        when (attributes_std -> 'logging_config') is not null then ' logging enabled'
         else ' logging disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -115,8 +115,8 @@ query "cloudfront_distribution_origin_access_identity_enabled" {
         from
           cloudfront_distribution,
           jsonb_array_elements(
-            case jsonb_typeof(arguments -> 'origin')
-            when 'array' then (arguments -> 'origin')
+            case jsonb_typeof(attributes_std -> 'origin')
+            when 'array' then (attributes_std -> 'origin')
             else null end
             ) as o
         where
@@ -129,8 +129,8 @@ query "cloudfront_distribution_origin_access_identity_enabled" {
         from
           cloudfront_distribution,
           jsonb_array_elements(
-            case jsonb_typeof(arguments -> 'origin')
-            when 'array' then (arguments -> 'origin')
+            case jsonb_typeof(attributes_std -> 'origin')
+            when 'array' then (attributes_std -> 'origin')
             else null end
             ) as o
         where
@@ -144,19 +144,19 @@ query "cloudfront_distribution_origin_access_identity_enabled" {
     select
       type || ' ' || a.name as resource,
       case
-        when (arguments -> 'origin') is null then 'alarm'
-        when (arguments -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (( not((arguments -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '')) and (arguments -> 'origin' -> 's3_origin_config' -> 'origin_access_identity') is not null) then 'ok'
-        when (arguments -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (((arguments -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '') or ((arguments -> 'origin' -> 's3_origin_config') is null)) then 'alarm'
+        when (attributes_std -> 'origin') is null then 'alarm'
+        when (attributes_std -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (( not((attributes_std -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '')) and (attributes_std -> 'origin' -> 's3_origin_config' -> 'origin_access_identity') is not null) then 'ok'
+        when (attributes_std -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (((attributes_std -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '') or ((attributes_std -> 'origin' -> 's3_origin_config') is null)) then 'alarm'
         when b.name is not null then 'alarm'
-        when (t.name is null ) and ((arguments -> 'origin' ->> 'domain_name') not like '%aws_s3_bucket%') then 'skip'
+        when (t.name is null ) and ((attributes_std -> 'origin' ->> 'domain_name') not like '%aws_s3_bucket%') then 'skip'
         else 'ok'
       end as status,
-      a.name || case
-        when (arguments -> 'origin') is null then ' origins not defined'
-        when (arguments -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (( not((arguments -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '')) and (arguments -> 'origin' -> 's3_origin_config' -> 'origin_access_identity') is not null) then ' origin access identity configured'
-        when (arguments -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (((arguments -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '') or ((arguments -> 'origin' -> 's3_origin_config') is null)) then ' origin access identity not configured'
+      a.address || case
+        when (attributes_std -> 'origin') is null then ' origins not defined'
+        when (attributes_std -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (( not((attributes_std -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '')) and (attributes_std -> 'origin' -> 's3_origin_config' -> 'origin_access_identity') is not null) then ' origin access identity configured'
+        when (attributes_std -> 'origin' ->> 'domain_name' ) like '%aws_s3_bucket%' and (((attributes_std -> 'origin' -> 's3_origin_config' ->> 'origin_access_identity') = '') or ((attributes_std -> 'origin' -> 's3_origin_config') is null)) then ' origin access identity not configured'
         when b.name is not null then ' origin access identity not configured'
-        when (t.name is null ) and ((arguments -> 'origin' ->> 'domain_name') not like '%aws_s3_bucket%') then ' origin type is not S3'
+        when (t.name is null ) and ((attributes_std -> 'origin' ->> 'domain_name') not like '%aws_s3_bucket%') then ' origin type is not S3'
         else ' origin access identity configured'
       end || '.' reason
       ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "a.")}
@@ -171,13 +171,13 @@ query "cloudfront_distribution_origin_access_identity_enabled" {
 query "cloudfront_distribution_waf_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'web_acl_id') is not null then 'ok'
+        when (attributes_std -> 'web_acl_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'web_acl_id') is not null then ' associated with WAF'
+      address || case
+        when (attributes_std -> 'web_acl_id') is not null then ' associated with WAF'
         else ' not associated with WAF'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -192,13 +192,13 @@ query "cloudfront_distribution_waf_enabled" {
 query "cloudfront_protocol_version_is_low" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'viewer_certificate' ->> 'minimum_protocol_version')::text = 'TLSv1.2_2019' then 'ok'
+        when (attributes_std -> 'viewer_certificate' ->> 'minimum_protocol_version')::text = 'TLSv1.2_2019' then 'ok'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'viewer_certificate' ->> 'minimum_protocol_version')::text = 'TLSv1.2_2019' then ' minimum protocol version is set to TLSv1.2_2019'
+      address || case
+        when (attributes_std -> 'viewer_certificate' ->> 'minimum_protocol_version')::text = 'TLSv1.2_2019' then ' minimum protocol version is set to TLSv1.2_2019'
         else ' minimum protocol version is not set to TLSv1.2_2019'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -213,20 +213,20 @@ query "cloudfront_protocol_version_is_low" {
 query "cloudfront_response_header_use_strict_transport_policy_setting" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'security_headers_config' -> 'strict_transport_security' ->> 'access_control_max_age_sec')::integer = 31536000
-        and (arguments -> 'security_headers_config' -> 'strict_transport_security' ->> 'include_subdomains')::boolean
-        and (arguments -> 'security_headers_config' -> 'strict_transport_security' ->> 'preload')::boolean
-        and (arguments -> 'security_headers_config' -> 'strict_transport_security' ->> 'override')::boolean
+        when (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'access_control_max_age_sec')::integer = 31536000
+        and (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'include_subdomains')::boolean
+        and (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'preload')::boolean
+        and (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'override')::boolean
         then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'security_headers_config' -> 'strict_transport_security' ->> 'access_control_max_age_sec')::integer = 31536000
-        and (arguments -> 'security_headers_config' -> 'strict_transport_security' ->> 'include_subdomains')::boolean
-        and (arguments -> 'security_headers_config' -> 'strict_transport_security' ->> 'preload')::boolean
-        and (arguments -> 'security_headers_config' -> 'strict_transport_security' ->> 'override')::boolean then ' enforces Strict Transport Security settings'
+      address || case
+        when (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'access_control_max_age_sec')::integer = 31536000
+        and (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'include_subdomains')::boolean
+        and (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'preload')::boolean
+        and (attributes_std -> 'security_headers_config' -> 'strict_transport_security' ->> 'override')::boolean then ' enforces Strict Transport Security settings'
         else ' does not enforce Strict Transport Security settings'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -241,13 +241,13 @@ query "cloudfront_response_header_use_strict_transport_policy_setting" {
 query "cloudfront_distribution_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'enabled')::boolean then 'ok'
+        when (attributes_std ->> 'enabled')::boolean then 'ok'
         else 'info'
       end status,
-      name || case
-        when(arguments ->> 'enabled')::boolean then ' is enabled'
+      address || case
+        when(attributes_std ->> 'enabled')::boolean then ' is enabled'
         else ' is disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/cloudsearch.sp
+++ b/query/cloudsearch.sp
@@ -6,7 +6,7 @@ query "cloudsearch_domain_enforced_https_enabled" {
         when (attributes_std -> 'endpoint_options' ->> 'enforce_https')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'endpoint_options' ->> 'enforce_https')::boolean then ' enforce https enabled'
         else ' enforce https disabled'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "cloudsearch_domain_uses_latest_tls_version" {
         when (attributes_std -> 'endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then ' uses latest TLS version'
         else ' uses old TLS version'
       end || '.' as reason

--- a/query/cloudsearch.sp
+++ b/query/cloudsearch.sp
@@ -1,13 +1,13 @@
 query "cloudsearch_domain_enforced_https_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'endpoint_options' ->> 'enforce_https')::boolean then 'ok'
+        when (attributes_std -> 'endpoint_options' ->> 'enforce_https')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'endpoint_options' ->> 'enforce_https')::boolean then ' enforce https enabled'
+      address || case
+        when (attributes_std -> 'endpoint_options' ->> 'enforce_https')::boolean then ' enforce https enabled'
         else ' enforce https disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "cloudsearch_domain_enforced_https_enabled" {
 query "cloudsearch_domain_uses_latest_tls_version" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then 'ok'
+        when (attributes_std -> 'endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then ' uses latest TLS version'
+      address || case
+        when (attributes_std -> 'endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then ' uses latest TLS version'
         else ' uses old TLS version'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/cloudtrail.sp
+++ b/query/cloudtrail.sp
@@ -8,7 +8,7 @@ query "cloudtrail_enabled_all_regions" {
         when (attributes_std -> 'event_selector' ->> 'read_write_type')::text <> 'All' then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'is_multi_region_trail') is null or (attributes_std ->> 'is_multi_region_trail')::boolean = 'false' then ' multi region trails not enabled'
         when (attributes_std ->> 'enable_logging') is null or (attributes_std ->> 'enable_logging')::boolean = 'false' then ' logging disabled'
         when (attributes_std -> 'event_selector' ->> 'read_write_type')::text <> 'All' then ' not enbaled for all events'
@@ -31,7 +31,7 @@ query "cloudtrail_trail_logs_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_id') is not null then ' logs are encrypted at rest'
         else ' logs are not encrypted at rest'
       end || '.' reason
@@ -52,7 +52,7 @@ query "cloudtrail_trail_validation_enabled" {
         when (attributes_std ->> 'enable_log_file_validation')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'enable_log_file_validation')::boolean then ' log file validation enabled'
         else ' log file validation disabled'
       end || '.' reason
@@ -73,7 +73,7 @@ query "cloudtrail_trail_sns_topic_enabled" {
         when (attributes_std ->> 'sns_topic_name') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'sns_topic_name') is not null then ' sns topic enabled'
         else ' sns topic disabled'
       end || '.' reason
@@ -94,7 +94,7 @@ query "cloudtrail_event_data_store_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is not null then ' event data store encrypted using KMS CMK'
         else ' event data store not encrypted using KMS CMK'
       end || '.' reason

--- a/query/cloudtrail.sp
+++ b/query/cloudtrail.sp
@@ -1,17 +1,17 @@
 query "cloudtrail_enabled_all_regions" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'is_multi_region_trail') is null or (arguments ->> 'is_multi_region_trail')::boolean = 'false' then 'alarm'
-        when (arguments ->> 'enable_logging') is null or (arguments ->> 'enable_logging')::boolean = 'false' then 'alarm'
-        when (arguments -> 'event_selector' ->> 'read_write_type')::text <> 'All' then 'alarm'
+        when (attributes_std ->> 'is_multi_region_trail') is null or (attributes_std ->> 'is_multi_region_trail')::boolean = 'false' then 'alarm'
+        when (attributes_std ->> 'enable_logging') is null or (attributes_std ->> 'enable_logging')::boolean = 'false' then 'alarm'
+        when (attributes_std -> 'event_selector' ->> 'read_write_type')::text <> 'All' then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments ->> 'is_multi_region_trail') is null or (arguments ->> 'is_multi_region_trail')::boolean = 'false' then ' multi region trails not enabled'
-        when (arguments ->> 'enable_logging') is null or (arguments ->> 'enable_logging')::boolean = 'false' then ' logging disabled'
-        when (arguments -> 'event_selector' ->> 'read_write_type')::text <> 'All' then ' not enbaled for all events'
+      address || case
+        when (attributes_std ->> 'is_multi_region_trail') is null or (attributes_std ->> 'is_multi_region_trail')::boolean = 'false' then ' multi region trails not enabled'
+        when (attributes_std ->> 'enable_logging') is null or (attributes_std ->> 'enable_logging')::boolean = 'false' then ' logging disabled'
+        when (attributes_std -> 'event_selector' ->> 'read_write_type')::text <> 'All' then ' not enbaled for all events'
         else ' logging enabled for ALL events'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -26,13 +26,13 @@ query "cloudtrail_enabled_all_regions" {
 query "cloudtrail_trail_logs_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_id') is not null then 'ok'
+        when (attributes_std -> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'kms_key_id') is not null then ' logs are encrypted at rest'
+      address || case
+        when (attributes_std -> 'kms_key_id') is not null then ' logs are encrypted at rest'
         else ' logs are not encrypted at rest'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -47,13 +47,13 @@ query "cloudtrail_trail_logs_encrypted_with_kms_cmk" {
 query "cloudtrail_trail_validation_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'enable_log_file_validation')::boolean then 'ok'
+        when (attributes_std ->> 'enable_log_file_validation')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'enable_log_file_validation')::boolean then ' log file validation enabled'
+      address || case
+        when (attributes_std ->> 'enable_log_file_validation')::boolean then ' log file validation enabled'
         else ' log file validation disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -68,13 +68,13 @@ query "cloudtrail_trail_validation_enabled" {
 query "cloudtrail_trail_sns_topic_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'sns_topic_name') is not null then 'ok'
+        when (attributes_std ->> 'sns_topic_name') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'sns_topic_name') is not null then ' sns topic enabled'
+      address || case
+        when (attributes_std ->> 'sns_topic_name') is not null then ' sns topic enabled'
         else ' sns topic disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -89,13 +89,13 @@ query "cloudtrail_trail_sns_topic_enabled" {
 query "cloudtrail_event_data_store_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is not null then 'ok'
+        when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'kms_key_id') is not null then ' event data store encrypted using KMS CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is not null then ' event data store encrypted using KMS CMK'
         else ' event data store not encrypted using KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/cloudwatch.sp
+++ b/query/cloudwatch.sp
@@ -51,7 +51,7 @@ query "cloudwatch_destination_policy_wildcards" {
         type = 'aws_cloudwatch_log_destination_policy'
     )
     select
-      type || ' ' || a.name as resource,
+      a.address as resource,
       case
         when e.name is null then 'ok'
         else 'alarm'

--- a/query/cloudwatch.sp
+++ b/query/cloudwatch.sp
@@ -1,20 +1,20 @@
 query "cloudwatch_alarm_action_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'alarm_actions') is null
-        and (arguments -> 'insufficient_data_actions') is null
-        and (arguments -> 'ok_actions') is null then 'alarm'
+        when (attributes_std -> 'alarm_actions') is null
+        and (attributes_std -> 'insufficient_data_actions') is null
+        and (attributes_std -> 'ok_actions') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'alarm_actions') is null
-        and (arguments -> 'insufficient_data_actions') is null
-        and (arguments -> 'ok_actions') is null then ' no action enabled'
-        when (arguments -> 'alarm_actions') is not null then ' alarm action enabled'
-        when (arguments -> 'insufficient_data_actions') is not null then ' insufficient data action enabled.'
-        when (arguments -> 'ok_actions') is not null then ' ok action enabled.'
+      address || case
+        when (attributes_std -> 'alarm_actions') is null
+        and (attributes_std -> 'insufficient_data_actions') is null
+        and (attributes_std -> 'ok_actions') is null then ' no action enabled'
+        when (attributes_std -> 'alarm_actions') is not null then ' alarm action enabled'
+        when (attributes_std -> 'insufficient_data_actions') is not null then ' insufficient data action enabled.'
+        when (attributes_std -> 'ok_actions') is not null then ' ok action enabled.'
         else ' action enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -40,10 +40,11 @@ query "cloudwatch_destination_policy_wildcards" {
       select
         name,
         type,
+        address,
         path,
         start_line,
         _ctx,
-        split_part((arguments ->> 'access_policy')::text, '.', 3) as ap
+        split_part((attributes_std ->> 'access_policy')::text, '.', 3) as ap
       from
         terraform_resource
       where
@@ -55,7 +56,7 @@ query "cloudwatch_destination_policy_wildcards" {
         when e.name is null then 'ok'
         else 'alarm'
       end as status,
-      a.name || case
+      a.address || case
         when e.name is null then ' policy is ok'
         else ' policy is not ok'
       end || '.' as reason
@@ -69,14 +70,14 @@ query "cloudwatch_destination_policy_wildcards" {
 query "cloudwatch_log_group_retention_period_365" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'retention_in_days') is null or (arguments -> 'retention_in_days')::int < 365 then 'alarm'
+        when (attributes_std -> 'retention_in_days') is null or (attributes_std -> 'retention_in_days')::int < 365 then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'retention_in_days') is null then ' retention period not set'
-        when (arguments -> 'retention_in_days')::int < 365 then ' retention period less than 365 days'
+      address || case
+        when (attributes_std -> 'retention_in_days') is null then ' retention period not set'
+        when (attributes_std -> 'retention_in_days')::int < 365 then ' retention period less than 365 days'
         else ' retention period 365 days or above'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -91,13 +92,13 @@ query "cloudwatch_log_group_retention_period_365" {
 query "log_group_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_id') is not null then 'ok'
+        when (attributes_std -> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'kms_key_id') is not null then ' encrypted at rest'
+      address || case
+        when (attributes_std -> 'kms_key_id') is not null then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -112,13 +113,13 @@ query "log_group_encryption_at_rest_enabled" {
 query "cloudwatch_log_group_retention" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'retention_in_days') is null then 'alarm'
+        when (attributes_std -> 'retention_in_days') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'retention_in_days') is null then ' retention period not set'
+      address || case
+        when (attributes_std -> 'retention_in_days') is null then ' retention period not set'
         else ' retention period set'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/cloudwatch.sp
+++ b/query/cloudwatch.sp
@@ -8,7 +8,7 @@ query "cloudwatch_alarm_action_enabled" {
         and (attributes_std -> 'ok_actions') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'alarm_actions') is null
         and (attributes_std -> 'insufficient_data_actions') is null
         and (attributes_std -> 'ok_actions') is null then ' no action enabled'
@@ -56,7 +56,7 @@ query "cloudwatch_destination_policy_wildcards" {
         when e.name is null then 'ok'
         else 'alarm'
       end as status,
-      a.address || case
+      split_part(a.address, '.', 2) || case
         when e.name is null then ' policy is ok'
         else ' policy is not ok'
       end || '.' as reason
@@ -75,7 +75,7 @@ query "cloudwatch_log_group_retention_period_365" {
         when (attributes_std -> 'retention_in_days') is null or (attributes_std -> 'retention_in_days')::int < 365 then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'retention_in_days') is null then ' retention period not set'
         when (attributes_std -> 'retention_in_days')::int < 365 then ' retention period less than 365 days'
         else ' retention period 365 days or above'
@@ -97,7 +97,7 @@ query "log_group_encryption_at_rest_enabled" {
         when (attributes_std -> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_id') is not null then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' reason
@@ -118,7 +118,7 @@ query "cloudwatch_log_group_retention" {
         when (attributes_std -> 'retention_in_days') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'retention_in_days') is null then ' retention period not set'
         else ' retention period set'
       end || '.' reason

--- a/query/codeartifact.sp
+++ b/query/codeartifact.sp
@@ -6,7 +6,7 @@ query "codeartifact_domain_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'encryption_key') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'encryption_key') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason

--- a/query/codeartifact.sp
+++ b/query/codeartifact.sp
@@ -1,13 +1,13 @@
 query "codeartifact_domain_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'encryption_key') is null then 'alarm'
+        when (attributes_std ->> 'encryption_key') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments ->> 'encryption_key') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std ->> 'encryption_key') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/codeartifact.sp
+++ b/query/codeartifact.sp
@@ -15,6 +15,6 @@ query "codeartifact_domain_encrypted_with_kms_cmk" {
     from
       terraform_resource
     where
-      type = 'aws_codeartifact_domain';    
+      type = 'aws_codeartifact_domain';
   EOQ
 }

--- a/query/codebuild.sp
+++ b/query/codebuild.sp
@@ -1,13 +1,13 @@
 query "codebuild_project_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when coalesce(trim(arguments ->> 'encryption_key'), '') = '' then 'alarm'
+        when coalesce(trim(attributes_std ->> 'encryption_key'), '') = '' then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when coalesce(trim(arguments ->> 'encryption_key'), '') = '' then ' not encrypted at rest'
+      address || case
+        when coalesce(trim(attributes_std ->> 'encryption_key'), '') = '' then ' not encrypted at rest'
         else ' encrypted at rest'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -34,8 +34,8 @@ query "codebuild_project_plaintext_env_variables_no_sensitive_aws_values" {
         from
           codebuild_projects,
           jsonb_array_elements(
-            case jsonb_typeof( arguments -> 'environment' -> 'environment_variable')
-              when 'array' then (arguments -> 'environment' -> 'environment_variable')
+            case jsonb_typeof( attributes_std -> 'environment' -> 'environment_variable')
+              when 'array' then (attributes_std -> 'environment' -> 'environment_variable')
               else null end
           ) as env
         where
@@ -46,12 +46,12 @@ query "codebuild_project_plaintext_env_variables_no_sensitive_aws_values" {
       type || ' ' || a.name as resource,
       case
         when b.name is not null
-        or ((arguments -> 'environment' -> 'environment_variable' ->> 'name' ilike any (ARRAY['%AWS_ACCESS_KEY_ID%', '%AWS_SECRET_ACCESS_KEY%', '%PASSWORD%'])) and arguments -> 'environment' -> 'environment_variable' ->> 'type' = 'PLAINTEXT') then 'alarm'
+        or ((attributes_std -> 'environment' -> 'environment_variable' ->> 'name' ilike any (ARRAY['%AWS_ACCESS_KEY_ID%', '%AWS_SECRET_ACCESS_KEY%', '%PASSWORD%'])) and attributes_std -> 'environment' -> 'environment_variable' ->> 'type' = 'PLAINTEXT') then 'alarm'
         else 'ok'
       end status,
-      a.name || case
+      a.address || case
         when b.name is not null
-        or ((arguments -> 'environment' -> 'environment_variable' ->> 'name' ilike any (ARRAY['%AWS_ACCESS_KEY_ID%', '%AWS_SECRET_ACCESS_KEY%', '%PASSWORD%'])) and arguments -> 'environment' -> 'environment_variable' ->> 'type' = 'PLAINTEXT') then ' has plaintext environment variables with sensitive AWS values'
+        or ((attributes_std -> 'environment' -> 'environment_variable' ->> 'name' ilike any (ARRAY['%AWS_ACCESS_KEY_ID%', '%AWS_SECRET_ACCESS_KEY%', '%PASSWORD%'])) and attributes_std -> 'environment' -> 'environment_variable' ->> 'type' = 'PLAINTEXT') then ' has plaintext environment variables with sensitive AWS values'
         else ' has no plaintext environment variables with sensitive AWS values'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -82,34 +82,34 @@ query "codebuild_project_source_repo_oauth_configured" {
     select
       a.type || ' ' || a.name as resource,
       case
-        when (a.arguments -> 'source' ->> 'type') not in ('GITHUB', 'BITBUCKET') then 'skip'
-        when (b.arguments ->> 'auth_type') = 'OAUTH' then 'ok'
+        when (a.attributes_std -> 'source' ->> 'type') not in ('GITHUB', 'BITBUCKET') then 'skip'
+        when (b.attributes_std ->> 'auth_type') = 'OAUTH' then 'ok'
         else 'alarm'
       end as status,
       case
-        when (a.arguments -> 'source' ->> 'type') = 'NO_SOURCE' then ' doesn''t have input source code.'
-        when (a.arguments -> 'source' ->> 'type') not in ('GITHUB', 'BITBUCKET') then ' source code isn''t in GitHub/Bitbucket repository'
-        when (b.arguments ->> 'auth_type') = 'OAUTH' then ' using OAuth to connect source repository'
+        when (a.attributes_std -> 'source' ->> 'type') = 'NO_SOURCE' then ' doesn''t have input source code.'
+        when (a.attributes_std -> 'source' ->> 'type') not in ('GITHUB', 'BITBUCKET') then ' source code isn''t in GitHub/Bitbucket repository'
+        when (b.attributes_std ->> 'auth_type') = 'OAUTH' then ' using OAuth to connect source repository'
         else ' not using OAuth to connect source repository'
       end || '.' reason
       ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "a.")}
       ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "a.")}
     from
       codebuild_projects as a
-      left join codebuild_source_credential as b on (b.arguments -> 'server_type') = (a.arguments -> 'source' -> 'type');
+      left join codebuild_source_credential as b on (b.attributes_std -> 'server_type') = (a.attributes_std -> 'source' -> 'type');
   EOQ
 }
 
 query "codebuild_project_s3_logs_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logs_config' -> 's3_logs' ->> 'encryption_disabled')::boolean then 'alarm'
+        when (attributes_std -> 'logs_config' -> 's3_logs' ->> 'encryption_disabled')::boolean then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'logs_config' -> 's3_logs' ->> 'encryption_disabled')::boolean then ' not encrypted at rest'
+      address || case
+        when (attributes_std -> 'logs_config' -> 's3_logs' ->> 'encryption_disabled')::boolean then ' not encrypted at rest'
         else ' encrypted at rest'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -124,15 +124,15 @@ query "codebuild_project_s3_logs_encryption_enabled" {
 query "codebuild_project_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logs_config' ->> 'cloudwatch_logs') is not null
-        or (arguments -> 'logs_config' ->> 's3_logs') is not null then 'ok'
+        when (attributes_std -> 'logs_config' ->> 'cloudwatch_logs') is not null
+        or (attributes_std -> 'logs_config' ->> 's3_logs') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'logs_config' ->> 'cloudwatch_logs') is not null
-        or (arguments -> 'logs_config' ->> 's3_logs') is not null then ' logging enabled'
+      address || case
+        when (attributes_std -> 'logs_config' ->> 'cloudwatch_logs') is not null
+        or (attributes_std -> 'logs_config' ->> 's3_logs') is not null then ' logging enabled'
         else ' logging disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -147,13 +147,13 @@ query "codebuild_project_logging_enabled" {
 query "codebuild_project_privileged_mode_disabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'environment' ->> 'privileged_mode')::boolean then 'alarm'
+        when (attributes_std -> 'environment' ->> 'privileged_mode')::boolean then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'environment' ->> 'privileged_mode')::boolean then ' has privileged mode enabled'
+      address || case
+        when (attributes_std -> 'environment' ->> 'privileged_mode')::boolean then ' has privileged mode enabled'
         else ' has privileged mode disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/codecommit.sp
+++ b/query/codecommit.sp
@@ -2,11 +2,11 @@ query "codecommit_approval_rule_template_number_of_approval_2" {
   sql = <<-EOQ
     with number_of_approvals_needed as (
       select
-        type || ' ' || name as name,
+        address as name,
         (s -> 'NumberOfApprovalsNeeded')::int as num_of_approval
       from
         terraform_resource,
-        jsonb_array_elements((arguments ->> 'content')::jsonb -> 'Statements') as s
+        jsonb_array_elements((attributes_std ->> 'content')::jsonb -> 'Statements') as s
       where
         type = 'aws_codecommit_approval_rule_template'
     )

--- a/query/codecommit.sp
+++ b/query/codecommit.sp
@@ -11,16 +11,16 @@ query "codecommit_approval_rule_template_number_of_approval_2" {
         type = 'aws_codecommit_approval_rule_template'
     )
     select
-      r.type || ' ' || r.name as resource,
+      r.address as resource,
       case
         when num_of_approval >= 2 then 'ok'
         else 'alarm'
       end as status,
-      r.name || ' number of approvals is set to ' || num_of_approval || '.' as reason
+      split_part(r.address, '.', 2) || ' number of approvals is set to ' || num_of_approval || '.' as reason
       ${local.common_dimensions_sql}
     from
       terraform_resource as r
-      left join number_of_approvals_needed as n on n.name = concat(r.type || ' ' || r.name)
+      left join number_of_approvals_needed as n on n.name = r.address
     where
       r.type = 'aws_codecommit_approval_rule_template';
   EOQ

--- a/query/codepipeline.sp
+++ b/query/codepipeline.sp
@@ -1,13 +1,13 @@
 query "codepipeline_artifacts_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'artifact_store' -> 'encryption_key' ->> 'id') is null then 'alarm'
+        when (attributes_std -> 'artifact_store' -> 'encryption_key' ->> 'id') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'artifact_store' -> 'encryption_key' ->> 'id') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'artifact_store' -> 'encryption_key' ->> 'id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/codepipeline.sp
+++ b/query/codepipeline.sp
@@ -6,7 +6,7 @@ query "codepipeline_artifacts_encrypted_with_kms_cmk" {
         when (attributes_std -> 'artifact_store' -> 'encryption_key' ->> 'id') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'artifact_store' -> 'encryption_key' ->> 'id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason

--- a/query/comprehend.sp
+++ b/query/comprehend.sp
@@ -6,7 +6,7 @@ query "comprehend_entity_recognizer_volume_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'volume_kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'volume_kms_key_id') is not null then ' uses KMS CMK'
         else ' does not use KMS CMK'
       end || '.' reason
@@ -27,7 +27,7 @@ query "comprehend_entity_recognizer_model_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'model_kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'model_kms_key_id') is not null then ' uses KMS CMK'
         else ' does not use KMS CMK'
       end || '.' reason

--- a/query/comprehend.sp
+++ b/query/comprehend.sp
@@ -1,13 +1,13 @@
 query "comprehend_entity_recognizer_volume_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'volume_kms_key_id') is not null then 'ok'
+        when (attributes_std ->> 'volume_kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'volume_kms_key_id') is not null then ' uses KMS CMK'
+      address || case
+        when (attributes_std ->> 'volume_kms_key_id') is not null then ' uses KMS CMK'
         else ' does not use KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "comprehend_entity_recognizer_volume_encrypted_with_kms_cmk" {
 query "comprehend_entity_recognizer_model_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'model_kms_key_id') is not null then 'ok'
+        when (attributes_std ->> 'model_kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'model_kms_key_id') is not null then ' uses KMS CMK'
+      address || case
+        when (attributes_std ->> 'model_kms_key_id') is not null then ' uses KMS CMK'
         else ' does not use KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/config.sp
+++ b/query/config.sp
@@ -6,7 +6,7 @@ query "config_aggregator_enabled_all_regions" {
         when (attributes_std -> 'account_aggregation_source' ->> 'all_regions')::boolean then 'ok'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'account_aggregation_source' ->> 'all_regions')::boolean then ' enabled in all regions'
         else ' not enabled in all regions'
       end || '.' as reason

--- a/query/config.sp
+++ b/query/config.sp
@@ -1,13 +1,13 @@
 query "config_aggregator_enabled_all_regions" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'account_aggregation_source' ->> 'all_regions')::boolean then 'ok'
+        when (attributes_std -> 'account_aggregation_source' ->> 'all_regions')::boolean then 'ok'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'account_aggregation_source' ->> 'all_regions')::boolean then ' enabled in all regions'
+      address || case
+        when (attributes_std -> 'account_aggregation_source' ->> 'all_regions')::boolean then ' enabled in all regions'
         else ' not enabled in all regions'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/connectinstance.sp
+++ b/query/connectinstance.sp
@@ -6,7 +6,7 @@ query "connect_instance_kinesis_video_stream_storage_config_encrypted_with_kms_c
         when (attributes_std -> 'storage_config' -> 'kinesis_video_stream_config' -> 'encryption_config' ->> 'key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'storage_config' -> 'kinesis_video_stream_config' -> 'encryption_config' ->> 'key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
@@ -27,7 +27,7 @@ query "connect_instance_s3_storage_config_encrypted_with_kms_cmk" {
         when (attributes_std -> 'storage_config' -> 's3_config' -> 'encryption_config' ->> 'key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'storage_config' -> 's3_config' -> 'encryption_config' ->> 'key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason

--- a/query/connectinstance.sp
+++ b/query/connectinstance.sp
@@ -1,13 +1,13 @@
 query "connect_instance_kinesis_video_stream_storage_config_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'storage_config' -> 'kinesis_video_stream_config' -> 'encryption_config' ->> 'key_id') is null then 'alarm'
+        when (attributes_std -> 'storage_config' -> 'kinesis_video_stream_config' -> 'encryption_config' ->> 'key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'storage_config' -> 'kinesis_video_stream_config' -> 'encryption_config' ->> 'key_id') is null then ' is not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'storage_config' -> 'kinesis_video_stream_config' -> 'encryption_config' ->> 'key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "connect_instance_kinesis_video_stream_storage_config_encrypted_with_kms_c
 query "connect_instance_s3_storage_config_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'storage_config' -> 's3_config' -> 'encryption_config' ->> 'key_id') is null then 'alarm'
+        when (attributes_std -> 'storage_config' -> 's3_config' -> 'encryption_config' ->> 'key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'storage_config' -> 's3_config' -> 'encryption_config' ->> 'key_id') is null then ' is not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'storage_config' -> 's3_config' -> 'encryption_config' ->> 'key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/datasync.sp
+++ b/query/datasync.sp
@@ -1,13 +1,13 @@
 query "datasync_location_object_storage_expose_secret" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'secret_key') is null then 'ok'
+        when (attributes_std -> 'secret_key') is null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'secret_key') is null then ' does not expose any secret key details'
+      address || case
+        when (attributes_std -> 'secret_key') is null then ' does not expose any secret key details'
         else ' exposes secret key details'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/datasync.sp
+++ b/query/datasync.sp
@@ -6,7 +6,7 @@ query "datasync_location_object_storage_expose_secret" {
         when (attributes_std -> 'secret_key') is null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'secret_key') is null then ' does not expose any secret key details'
         else ' exposes secret key details'
       end || '.' as reason

--- a/query/dax.sp
+++ b/query/dax.sp
@@ -6,7 +6,7 @@ query "dax_cluster_encryption_at_rest_enabled" {
         when (attributes_std -> 'server_side_encryption') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'server_side_encryption') is null then ' encryption at rest disabled'
         else ' encryption at rest disabled enabled'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "dax_cluster_endpoint_encryption_tls_enabled" {
         when (attributes_std ->> 'cluster_endpoint_encryption_type') = 'TLS' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'cluster_endpoint_encryption_type') = 'TLS' then ' endpoint encryption tls enabled'
         else ' endpoint encryption tls disabled'
       end || '.' as reason

--- a/query/dax.sp
+++ b/query/dax.sp
@@ -1,13 +1,13 @@
 query "dax_cluster_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'server_side_encryption') is null then 'alarm'
+        when (attributes_std -> 'server_side_encryption') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'server_side_encryption') is null then ' encryption at rest disabled'
+      address || case
+        when (attributes_std -> 'server_side_encryption') is null then ' encryption at rest disabled'
         else ' encryption at rest disabled enabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "dax_cluster_encryption_at_rest_enabled" {
 query "dax_cluster_endpoint_encryption_tls_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'cluster_endpoint_encryption_type') = 'TLS' then 'ok'
+        when (attributes_std ->> 'cluster_endpoint_encryption_type') = 'TLS' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'cluster_endpoint_encryption_type') = 'TLS' then ' endpoint encryption tls enabled'
+      address || case
+        when (attributes_std ->> 'cluster_endpoint_encryption_type') = 'TLS' then ' endpoint encryption tls enabled'
         else ' endpoint encryption tls disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/dlm.sp
+++ b/query/dlm.sp
@@ -6,7 +6,7 @@ query "dlm_lifecycle_policy_events_cross_region_encryption_enabled" {
         when (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean  then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean then ' events cross-region encryption enabled'
         else ' events cross-region encryption disabled'
       end || '.' reason
@@ -27,7 +27,7 @@ query "dlm_lifecycle_policy_events_cross_region_encrypted_with_kms_cmk" {
         when (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean and (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'cmk_arn') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean and (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'cmk_arn') is not null then ' events cross-region encrypted with KMS CMK'
         else ' events cross-region not encrypted with KMS CMK'
       end || '.' reason
@@ -49,7 +49,7 @@ query "dlm_schedule_cross_region_encryption_enabled" {
         when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean  then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then ' schedule cross-region not configured'
         when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean then ' schedule cross-region encryption enabled'
         else ' schedule cross-region encryption disabled'
@@ -72,7 +72,7 @@ query "dlm_schedule_cross_region_encrypted_with_kms_cmk" {
         when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean and (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'cmk_arn') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then ' schedule cross-region not configured'
         when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean and (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'cmk_arn') is not null then ' schedule cross-region encrypted with KMS CMK'
         else ' schedule cross-region not encrypted with KMS CMK'

--- a/query/dlm.sp
+++ b/query/dlm.sp
@@ -3,7 +3,7 @@ query "dlm_lifecycle_policy_events_cross_region_encryption_enabled" {
     select
       address as resource,
       case
-        when (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean  then 'ok'
+        when (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean then 'ok'
         else 'alarm'
       end status,
       split_part(address, '.', 2) || case
@@ -46,7 +46,7 @@ query "dlm_schedule_cross_region_encryption_enabled" {
       address as resource,
       case
         when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then 'skip'
-        when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean  then 'ok'
+        when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean then 'ok'
         else 'alarm'
       end status,
       split_part(address, '.', 2) || case

--- a/query/dlm.sp
+++ b/query/dlm.sp
@@ -1,13 +1,13 @@
 query "dlm_lifecycle_policy_events_cross_region_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean  then 'ok'
+        when (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean  then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean then ' events cross-region encryption enabled'
+      address || case
+        when (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean then ' events cross-region encryption enabled'
         else ' events cross-region encryption disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "dlm_lifecycle_policy_events_cross_region_encryption_enabled" {
 query "dlm_lifecycle_policy_events_cross_region_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean and (arguments -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'cmk_arn') is not null then 'ok'
+        when (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean and (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'cmk_arn') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean and (arguments -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'cmk_arn') is not null then ' events cross-region encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'encrypted')::boolean and (attributes_std -> 'policy_details' -> 'action' -> 'cross_region_copy' -> 'encryption_configuration' ->> 'cmk_arn') is not null then ' events cross-region encrypted with KMS CMK'
         else ' events cross-region not encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -43,15 +43,15 @@ query "dlm_lifecycle_policy_events_cross_region_encrypted_with_kms_cmk" {
 query "dlm_schedule_cross_region_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then 'skip'
-        when (arguments -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean  then 'ok'
+        when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then 'skip'
+        when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean  then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then ' schedule cross-region not configured'
-        when (arguments -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean then ' schedule cross-region encryption enabled'
+      address || case
+        when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then ' schedule cross-region not configured'
+        when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean then ' schedule cross-region encryption enabled'
         else ' schedule cross-region encryption disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -66,15 +66,15 @@ query "dlm_schedule_cross_region_encryption_enabled" {
 query "dlm_schedule_cross_region_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then 'skip'
-        when (arguments -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean and (arguments -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'cmk_arn') is not null then 'ok'
+        when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then 'skip'
+        when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean and (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'cmk_arn') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then ' schedule cross-region not configured'
-        when (arguments -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean and (arguments -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'cmk_arn') is not null then ' schedule cross-region encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule') is null then ' schedule cross-region not configured'
+        when (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'encrypted')::boolean and (attributes_std -> 'policy_details' -> 'schedule' -> 'cross_region_copy_rule' ->> 'cmk_arn') is not null then ' schedule cross-region encrypted with KMS CMK'
         else ' schedule cross-region not encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/dms.sp
+++ b/query/dms.sp
@@ -7,7 +7,7 @@ query "dms_replication_instance_not_publicly_accessible" {
         when (attributes_std -> 'publicly_accessible')::bool then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'publicly_accessible') is null then ' not publicly accessible'
         when (attributes_std -> 'publicly_accessible')::bool then ' publicly accessible'
         else ' not publicly accessible'
@@ -29,7 +29,7 @@ query "dms_replication_instance_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
@@ -50,7 +50,7 @@ query "dms_replication_instance_automatic_minor_version_upgrade_enabled" {
         when (attributes_std -> 'auto_minor_version_upgrade')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'auto_minor_version_upgrade')::bool then ' automatic minor version upgrade enabled'
         else ' automatic minor version upgrade disabled'
       end || '.' as reason
@@ -71,7 +71,7 @@ query "dms_s3_endpoint_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason

--- a/query/dms.sp
+++ b/query/dms.sp
@@ -1,15 +1,15 @@
 query "dms_replication_instance_not_publicly_accessible" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'publicly_accessible') is null then 'ok'
-        when (arguments -> 'publicly_accessible')::bool then 'alarm'
+        when (attributes_std -> 'publicly_accessible') is null then 'ok'
+        when (attributes_std -> 'publicly_accessible')::bool then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'publicly_accessible') is null then ' not publicly accessible'
-        when (arguments -> 'publicly_accessible')::bool then ' publicly accessible'
+      address || case
+        when (attributes_std -> 'publicly_accessible') is null then ' not publicly accessible'
+        when (attributes_std -> 'publicly_accessible')::bool then ' publicly accessible'
         else ' not publicly accessible'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -24,13 +24,13 @@ query "dms_replication_instance_not_publicly_accessible" {
 query "dms_replication_instance_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_arn') is null then 'alarm'
+        when (attributes_std -> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -45,13 +45,13 @@ query "dms_replication_instance_encrypted_with_kms_cmk" {
 query "dms_replication_instance_automatic_minor_version_upgrade_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'auto_minor_version_upgrade')::bool then 'ok'
+        when (attributes_std -> 'auto_minor_version_upgrade')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'auto_minor_version_upgrade')::bool then ' automatic minor version upgrade enabled'
+      address || case
+        when (attributes_std -> 'auto_minor_version_upgrade')::bool then ' automatic minor version upgrade enabled'
         else ' automatic minor version upgrade disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -66,13 +66,13 @@ query "dms_replication_instance_automatic_minor_version_upgrade_enabled" {
 query "dms_s3_endpoint_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_arn') is null then 'alarm'
+        when (attributes_std -> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/docdb.sp
+++ b/query/docdb.sp
@@ -7,7 +7,7 @@ query "docdb_cluster_audit_logs_enabled" {
         when '"audit"' in (select jsonb_array_elements(attributes_std -> 'enabled_cloudwatch_logs_exports') from terraform_resource where type = 'aws_docdb_cluster') then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'enabled_cloudwatch_logs_exports') is null then ' logging not enabled'
         when '"audit"' in (select jsonb_array_elements(attributes_std -> 'enabled_cloudwatch_logs_exports') from terraform_resource where type = 'aws_docdb_cluster') then ' audit logging enabled'
         else ' audit logging not enabled'
@@ -32,7 +32,7 @@ query "docdb_cluster_encrypted_with_kms" {
         then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when
           (attributes_std ->> 'storage_encrypted')::boolean
           and coalesce(trim(attributes_std ->> 'kms_key_id'), '') <> ''
@@ -59,7 +59,7 @@ query "docdb_cluster_paramater_group_logging_enabled" {
         then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when
           (attributes_std -> 'parameter'->> 'name') = 'audit_logs'
           and (attributes_std -> 'parameter'->> 'value') = 'enabled'
@@ -85,7 +85,7 @@ query "docdb_global_cluster_encrypted" {
         then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when
           (attributes_std ->> 'storage_encrypted')::boolean
         then ' Global Cluster is encrypted'
@@ -110,7 +110,7 @@ query "docdb_cluster_log_exports_enabled" {
         then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when
           (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
         then ' cloudwatch log exports enabled'
@@ -136,7 +136,7 @@ query "docdb_cluster_parameter_group_tls_enabled" {
         then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when
           (attributes_std -> 'parameter'->> 'name') = 'tls'
           and (attributes_std -> 'parameter'->> 'value') = 'enabled'

--- a/query/docdb.sp
+++ b/query/docdb.sp
@@ -1,15 +1,15 @@
 query "docdb_cluster_audit_logs_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'enabled_cloudwatch_logs_exports') is null then 'alarm'
-        when '"audit"' in (select jsonb_array_elements(arguments -> 'enabled_cloudwatch_logs_exports') from terraform_resource where type = 'aws_docdb_cluster') then 'ok'
+        when (attributes_std -> 'enabled_cloudwatch_logs_exports') is null then 'alarm'
+        when '"audit"' in (select jsonb_array_elements(attributes_std -> 'enabled_cloudwatch_logs_exports') from terraform_resource where type = 'aws_docdb_cluster') then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'enabled_cloudwatch_logs_exports') is null then ' logging not enabled'
-        when '"audit"' in (select jsonb_array_elements(arguments -> 'enabled_cloudwatch_logs_exports') from terraform_resource where type = 'aws_docdb_cluster') then ' audit logging enabled'
+      address || case
+        when (attributes_std -> 'enabled_cloudwatch_logs_exports') is null then ' logging not enabled'
+        when '"audit"' in (select jsonb_array_elements(attributes_std -> 'enabled_cloudwatch_logs_exports') from terraform_resource where type = 'aws_docdb_cluster') then ' audit logging enabled'
         else ' audit logging not enabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -24,18 +24,18 @@ query "docdb_cluster_audit_logs_enabled" {
 query "docdb_cluster_encrypted_with_kms" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-          (arguments ->> 'storage_encrypted')::boolean
-          and coalesce(trim(arguments ->> 'kms_key_id'), '') <> ''
+          (attributes_std ->> 'storage_encrypted')::boolean
+          and coalesce(trim(attributes_std ->> 'kms_key_id'), '') <> ''
         then 'ok'
         else 'alarm'
       end as status,
-      name || case
+      address || case
         when
-          (arguments ->> 'storage_encrypted')::boolean
-          and coalesce(trim(arguments ->> 'kms_key_id'), '') <> ''
+          (attributes_std ->> 'storage_encrypted')::boolean
+          and coalesce(trim(attributes_std ->> 'kms_key_id'), '') <> ''
         then ' encrypted at rest using KMS CMK'
         else ' not encrypted at rest using KMS CMK'
       end || '.' as reason
@@ -51,18 +51,18 @@ query "docdb_cluster_encrypted_with_kms" {
 query "docdb_cluster_paramater_group_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-         (arguments -> 'parameter'->> 'name') = 'audit_logs'
-         and (arguments -> 'parameter'->> 'value') = 'enabled'
+         (attributes_std -> 'parameter'->> 'name') = 'audit_logs'
+         and (attributes_std -> 'parameter'->> 'value') = 'enabled'
         then 'ok'
         else 'alarm'
       end as status,
-      name || case
+      address || case
         when
-          (arguments -> 'parameter'->> 'name') = 'audit_logs'
-          and (arguments -> 'parameter'->> 'value') = 'enabled'
+          (attributes_std -> 'parameter'->> 'name') = 'audit_logs'
+          and (attributes_std -> 'parameter'->> 'value') = 'enabled'
         then ' logging enabled'
         else ' logging disabled'
       end || '.' as reason
@@ -78,16 +78,16 @@ query "docdb_cluster_paramater_group_logging_enabled" {
 query "docdb_global_cluster_encrypted" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-          (arguments ->> 'storage_encrypted')::boolean
+          (attributes_std ->> 'storage_encrypted')::boolean
         then 'ok'
         else 'alarm'
       end as status,
-      name || case
+      address || case
         when
-          (arguments ->> 'storage_encrypted')::boolean
+          (attributes_std ->> 'storage_encrypted')::boolean
         then ' Global Cluster is encrypted'
         else ' Global Cluster is not encrypted'
       end || '.' as reason
@@ -103,16 +103,16 @@ query "docdb_global_cluster_encrypted" {
 query "docdb_cluster_log_exports_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-         (arguments -> 'enabled_cloudwatch_logs_exports') is not null
+         (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
         then 'ok'
         else 'alarm'
       end as status,
-      name || case
+      address || case
         when
-          (arguments -> 'enabled_cloudwatch_logs_exports') is not null
+          (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
         then ' cloudwatch log exports enabled'
         else ' cloudwatch log exports disabled'
       end || '.' as reason
@@ -128,18 +128,18 @@ query "docdb_cluster_log_exports_enabled" {
 query "docdb_cluster_parameter_group_tls_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-         (arguments -> 'parameter'->> 'name') = 'tls'
-         and (arguments -> 'parameter'->> 'value') = 'enabled'
+         (attributes_std -> 'parameter'->> 'name') = 'tls'
+         and (attributes_std -> 'parameter'->> 'value') = 'enabled'
         then 'ok'
         else 'alarm'
       end as status,
-      name || case
+      address || case
         when
-          (arguments -> 'parameter'->> 'name') = 'tls'
-          and (arguments -> 'parameter'->> 'value') = 'enabled'
+          (attributes_std -> 'parameter'->> 'name') = 'tls'
+          and (attributes_std -> 'parameter'->> 'value') = 'enabled'
         then ' TLS enabled'
         else ' TLS disabled'
       end || '.' as reason

--- a/query/dynamodb.sp
+++ b/query/dynamodb.sp
@@ -1,17 +1,17 @@
 query "dynamodb_table_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         -- // kms_key_arn - This attribute should only be specified if the key is different from the default DynamoDB CMK, alias/aws/dynamodb.
         -- This query only checks if table is encrypted by default AWS KMS i.e. If enabled is false then server-side encryption is set to AWS owned CMK
-        when (arguments -> 'server_side_encryption' ->> 'enabled')::bool is false then 'alarm'
-        when (arguments -> 'server_side_encryption'->> 'enabled')::bool is true and (arguments -> 'server_side_encryption' ->> 'kms_key_arn') is not null then 'ok'
+        when (attributes_std -> 'server_side_encryption' ->> 'enabled')::bool is false then 'alarm'
+        when (attributes_std -> 'server_side_encryption'->> 'enabled')::bool is true and (attributes_std -> 'server_side_encryption' ->> 'kms_key_arn') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'server_side_encryption' ->> 'enabled')::bool is false then ' encrypted by DynamoDB managed and owned AWS KMS key'
-        when (arguments -> 'server_side_encryption'->> 'enabled')::bool is true and (arguments -> 'server_side_encryption' ->> 'kms_key_arn') is not null then ' encrypted by AWS managed CMK'
+      address || case
+        when (attributes_std -> 'server_side_encryption' ->> 'enabled')::bool is false then ' encrypted by DynamoDB managed and owned AWS KMS key'
+        when (attributes_std -> 'server_side_encryption'->> 'enabled')::bool is true and (attributes_std -> 'server_side_encryption' ->> 'kms_key_arn') is not null then ' encrypted by AWS managed CMK'
         else ' not encrypted by AWS managed CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -26,13 +26,13 @@ query "dynamodb_table_encrypted_with_kms_cmk" {
 query "dynamodb_table_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'server_side_encryption') is not null then 'ok'
+        when (attributes_std -> 'server_side_encryption') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'server_side_encryption') is not null then ' server-side encryption not set to DynamoDB owned KMS key'
+      address || case
+        when (attributes_std -> 'server_side_encryption') is not null then ' server-side encryption not set to DynamoDB owned KMS key'
         else ' server-side encryption set to AWS owned CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -47,15 +47,15 @@ query "dynamodb_table_encryption_enabled" {
 query "dynamodb_table_point_in_time_recovery_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'point_in_time_recovery') is null then 'alarm'
-        when (arguments -> 'point_in_time_recovery' ->> 'enabled')::boolean then 'ok'
+        when (attributes_std -> 'point_in_time_recovery') is null then 'alarm'
+        when (attributes_std -> 'point_in_time_recovery' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'point_in_time_recovery') is null then ' ''point_in_time_recovery'' disabled'
-        when (arguments -> 'point_in_time_recovery' ->> 'enabled')::boolean then ' ''point_in_time_recovery'' enabled'
+      address || case
+        when (attributes_std -> 'point_in_time_recovery') is null then ' ''point_in_time_recovery'' disabled'
+        when (attributes_std -> 'point_in_time_recovery' ->> 'enabled')::boolean then ' ''point_in_time_recovery'' enabled'
         else ' ''point_in_time_recovery'' disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -70,15 +70,15 @@ query "dynamodb_table_point_in_time_recovery_enabled" {
 query "dynamodb_vpc_endpoint_routetable_association" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'service_name') like '%dynamodb%' and (arguments -> 'route_table_ids') is null then 'alarm'
-        when (arguments ->> 'service_name') like '%dynamodb%' and (arguments -> 'route_table_ids') is not null then 'ok'
+        when (attributes_std ->> 'service_name') like '%dynamodb%' and (attributes_std -> 'route_table_ids') is null then 'alarm'
+        when (attributes_std ->> 'service_name') like '%dynamodb%' and (attributes_std -> 'route_table_ids') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'service_name') like '%dynamodb%' and (arguments -> 'route_table_ids') is null then ' VPC Endpoint for DynamoDB disabled'
-        when (arguments ->> 'service_name') like '%dynamodb%' and (arguments -> 'route_table_ids') is not null then ' VPC Endpoint for DynamoDB enabled'
+      address || case
+        when (attributes_std ->> 'service_name') like '%dynamodb%' and (attributes_std -> 'route_table_ids') is null then ' VPC Endpoint for DynamoDB disabled'
+        when (attributes_std ->> 'service_name') like '%dynamodb%' and (attributes_std -> 'route_table_ids') is not null then ' VPC Endpoint for DynamoDB enabled'
         else ' VPC Endpoint for DynamoDB disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/dynamodb.sp
+++ b/query/dynamodb.sp
@@ -9,7 +9,7 @@ query "dynamodb_table_encrypted_with_kms_cmk" {
         when (attributes_std -> 'server_side_encryption'->> 'enabled')::bool is true and (attributes_std -> 'server_side_encryption' ->> 'kms_key_arn') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'server_side_encryption' ->> 'enabled')::bool is false then ' encrypted by DynamoDB managed and owned AWS KMS key'
         when (attributes_std -> 'server_side_encryption'->> 'enabled')::bool is true and (attributes_std -> 'server_side_encryption' ->> 'kms_key_arn') is not null then ' encrypted by AWS managed CMK'
         else ' not encrypted by AWS managed CMK'
@@ -31,7 +31,7 @@ query "dynamodb_table_encryption_enabled" {
         when (attributes_std -> 'server_side_encryption') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'server_side_encryption') is not null then ' server-side encryption not set to DynamoDB owned KMS key'
         else ' server-side encryption set to AWS owned CMK'
       end || '.' as reason
@@ -53,7 +53,7 @@ query "dynamodb_table_point_in_time_recovery_enabled" {
         when (attributes_std -> 'point_in_time_recovery' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'point_in_time_recovery') is null then ' ''point_in_time_recovery'' disabled'
         when (attributes_std -> 'point_in_time_recovery' ->> 'enabled')::boolean then ' ''point_in_time_recovery'' enabled'
         else ' ''point_in_time_recovery'' disabled'
@@ -76,7 +76,7 @@ query "dynamodb_vpc_endpoint_routetable_association" {
         when (attributes_std ->> 'service_name') like '%dynamodb%' and (attributes_std -> 'route_table_ids') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'service_name') like '%dynamodb%' and (attributes_std -> 'route_table_ids') is null then ' VPC Endpoint for DynamoDB disabled'
         when (attributes_std ->> 'service_name') like '%dynamodb%' and (attributes_std -> 'route_table_ids') is not null then ' VPC Endpoint for DynamoDB enabled'
         else ' VPC Endpoint for DynamoDB disabled'

--- a/query/ebs.sp
+++ b/query/ebs.sp
@@ -7,7 +7,7 @@ query "ebs_volume_encryption_at_rest_enabled" {
         when (attributes_std ->> 'encrypted')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encrypted') is null then ' ''encrypted'' is not defined'
         when (attributes_std ->> 'encrypted')::bool then ' encrypted'
         else ' not encrypted'
@@ -30,7 +30,7 @@ query "ebs_snapshot_copy_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'encrypted')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encrypted') is null then ' ''encrypted'' is not defined'
         when (attributes_std ->> 'encrypted')::bool then ' encrypted'
         else ' not encrypted'

--- a/query/ebs.sp
+++ b/query/ebs.sp
@@ -1,15 +1,15 @@
 query "ebs_volume_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encrypted') is null then 'alarm'
-        when (arguments ->> 'encrypted')::bool then 'ok'
+        when (attributes_std -> 'encrypted') is null then 'alarm'
+        when (attributes_std ->> 'encrypted')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'encrypted') is null then ' ''encrypted'' is not defined'
-        when (arguments ->> 'encrypted')::bool then ' encrypted'
+      address || case
+        when (attributes_std -> 'encrypted') is null then ' ''encrypted'' is not defined'
+        when (attributes_std ->> 'encrypted')::bool then ' encrypted'
         else ' not encrypted'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -24,15 +24,15 @@ query "ebs_volume_encryption_at_rest_enabled" {
 query "ebs_snapshot_copy_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encrypted') is null then 'alarm'
-        when (arguments ->> 'encrypted')::bool then 'ok'
+        when (attributes_std -> 'encrypted') is null then 'alarm'
+        when (attributes_std ->> 'encrypted')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'encrypted') is null then ' ''encrypted'' is not defined'
-        when (arguments ->> 'encrypted')::bool then ' encrypted'
+      address || case
+        when (attributes_std -> 'encrypted') is null then ' ''encrypted'' is not defined'
+        when (attributes_std ->> 'encrypted')::bool then ' encrypted'
         else ' not encrypted'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/ec2.sp
+++ b/query/ec2.sp
@@ -7,7 +7,7 @@ query "ec2_classic_lb_connection_draining_enabled" {
         when (attributes_std -> 'connection_draining')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'connection_draining') is null then ' ''connection_draining'' disabled'
         when (attributes_std -> 'connection_draining')::bool then ' ''connection_draining'' enabled'
         else ' ''connection_draining'' disabled'
@@ -30,7 +30,7 @@ query "ec2_ebs_default_encryption_enabled" {
         when (attributes_std ->> 'enabled')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'enabled') is null then ' ''enabled'' is not defined'
         when (attributes_std ->> 'enabled')::bool then ' default EBS encryption enabled'
         else ' default EBS encryption disabled'
@@ -51,7 +51,7 @@ query "ec2_instance_detailed_monitoring_enabled" {
         when (attributes_std ->> 'monitoring')::bool is true then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'monitoring')::bool is true then ' detailed monitoring enabled'
         else ' detailed monitoring disabled'
       end || '.' as reason
@@ -72,7 +72,7 @@ query "ec2_instance_ebs_optimized" {
         when (attributes_std -> 'ebs_optimized')::bool is true then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'ebs_optimized')::bool is true then ' EBS optimization enabled'
         else ' EBS optimization disabled'
       end || '.' as reason
@@ -93,7 +93,7 @@ query "ec2_instance_not_publicly_accessible" {
         when (attributes_std -> 'associate_public_ip_address') is null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'associate_public_ip_address') is null then ' not publicly accessible'
         else ' publicly accessible'
       end || '.' reason
@@ -115,7 +115,7 @@ query "ec2_instance_not_use_default_vpc" {
         when split_part((attributes_std ->> 'subnet_id'), '.', 2) in (select name from terraform_resource where type = 'aws_subnet' and (attributes_std ->> 'vpc_id') like '%default%') then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'subnet_id') is null then ' does not have a subnet id defined'
         when split_part((attributes_std ->> 'subnet_id'), '.', 2) in (select name from terraform_resource where type = 'aws_subnet' and (attributes_std ->> 'vpc_id') like '%default%') then ' deployed to a default VPC'
         else ' not deployed to a default VPC'
@@ -138,7 +138,7 @@ query "ec2_instance_not_use_multiple_enis" {
         when (jsonb_typeof(attributes_std -> 'network_interface'))::text = 'object' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when jsonb_typeof(attributes_std -> 'network_interface') is null then ' has no ENI attached'
         when (jsonb_typeof(attributes_std -> 'network_interface'))::text = 'object' then ' has 1 ENI attached'
         else ' has ' || (jsonb_array_length(attributes_std -> 'network_interface')) || ' ENI(s) attached'
@@ -160,7 +160,7 @@ query "ec2_instance_termination_protection_enabled" {
         when (attributes_std -> 'root_block_device' ->> 'delete_on_termination')::bool is true then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'root_block_device' ->> 'delete_on_termination')::bool is true then ' instance termination protection enabled'
         else ' instance termination protection disabled'
       end || '.' as reason
@@ -181,7 +181,7 @@ query "ec2_instance_uses_imdsv2" {
         when coalesce(trim(attributes_std -> 'metadata_options' ->> 'http_tokens'),'') in ('optional', '') then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'metadata_options' -> 'http_tokens') is null then ' ''http_tokens'' is not defined'
         when (attributes_std -> 'metadata_options' ->> 'http_tokens') = 'optional'
         then ' not configured to use Instance Metadata Service Version 2 (IMDSv2)'
@@ -206,7 +206,7 @@ query "ec2_instance_user_data_no_secrets" {
           or (attributes_std ->> 'user_data') ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]' then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'user_data') is null then ' no user data defined.'
         when (attributes_std ->> 'user_data') like any (array ['%pass%', '%secret%','%token%','%key%'])
           or (attributes_std ->> 'user_data') ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]' then ' potential secret found in user data.'
@@ -229,7 +229,7 @@ query "ec2_ami_imagebuilder_component_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is null then ' is not encrypted with CMK'
         else ' is encrypted with CMK'
       end || '.' as reason
@@ -250,7 +250,7 @@ query "ec2_ami_imagebuilder_distribution_configuration_encrypted_with_kms_cmk" {
         when (attributes_std -> 'distribution' -> 'ami_distribution_configuration' ->> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'distribution' -> 'ami_distribution_configuration' ->> 'kms_key_id') is null then ' is not encrypted with CMK'
         else ' is encrypted with CMK'
       end || '.' as reason
@@ -271,7 +271,7 @@ query "ec2_ami_imagebuilder_image_recipe_encrypted_with_kms_cmk" {
         when (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'kms_key_id') is null or (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') <> 'true' or (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'kms_key_id') is null or (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') <> 'true' or (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') is null then ' is not encrypted with CMK'
         else ' is encrypted with CMK'
       end || '.' as reason
@@ -292,7 +292,7 @@ query "ec2_launch_template_metadata_hop_limit_check" {
         when (attributes_std -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then ' metadata response hop limit value is greater than 1'
         else ' metadata response hop limit value is not less than 1'
       end || '.' as reason
@@ -313,7 +313,7 @@ query "ec2_launch_configuration_metadata_hop_limit_check" {
         when (attributes_std -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then ' metadata response hop limit value is greater than 1'
         else ' metadata response hop limit value is less than 1'
       end || '.' as reason
@@ -334,7 +334,7 @@ query "ec2_launch_configuration_ebs_encryption_check" {
         when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then ' is securely encrypted'
         else ' is not securely encrypted'
       end || '.' as reason
@@ -355,7 +355,7 @@ query "ec2_instance_ebs_encryption_check" {
         when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then ' is securely encrypted'
         else ' is not securely encrypted'
       end || '.' as reason
@@ -376,7 +376,7 @@ query "ec2_ami_copy_encryption_enabled" {
         when (attributes_std ->> 'encrypted') = 'true' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'encrypted') = 'true' then ' is encrypted'
         else ' is not encrypted'
       end || '.' as reason
@@ -397,7 +397,7 @@ query "ec2_ami_copy_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is not null then ' is encrypted with CMK'
         else ' is not encrypted with CMK'
       end || '.' as reason
@@ -418,7 +418,7 @@ query "ec2_ami_encryption_enabled" {
         when (attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null then ' is encrypted'
         else ' is not encrypted'
       end || '.' as reason
@@ -442,7 +442,7 @@ query "ec2_ami_launch_permission_restricted" {
         when (attributes_std -> 'organizational_unit_arn') is not null then 'info'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'account_id') is not null then ' is restrictive to account(s)'
         when (attributes_std -> 'group') is not null then ' is open to IAM group'
         when (attributes_std -> 'organizational_arn') is not null then ' is open to organization'

--- a/query/ec2.sp
+++ b/query/ec2.sp
@@ -1,15 +1,15 @@
 query "ec2_classic_lb_connection_draining_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'connection_draining') is null then 'alarm'
-        when (arguments -> 'connection_draining')::bool then 'ok'
+        when (attributes_std -> 'connection_draining') is null then 'alarm'
+        when (attributes_std -> 'connection_draining')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'connection_draining') is null then ' ''connection_draining'' disabled'
-        when (arguments -> 'connection_draining')::bool then ' ''connection_draining'' enabled'
+      address || case
+        when (attributes_std -> 'connection_draining') is null then ' ''connection_draining'' disabled'
+        when (attributes_std -> 'connection_draining')::bool then ' ''connection_draining'' enabled'
         else ' ''connection_draining'' disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -24,15 +24,15 @@ query "ec2_classic_lb_connection_draining_enabled" {
 query "ec2_ebs_default_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'enabled') is null then 'alarm'
-        when (arguments ->> 'enabled')::bool then 'ok'
+        when (attributes_std -> 'enabled') is null then 'alarm'
+        when (attributes_std ->> 'enabled')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'enabled') is null then ' ''enabled'' is not defined'
-        when (arguments ->> 'enabled')::bool then ' default EBS encryption enabled'
+      address || case
+        when (attributes_std -> 'enabled') is null then ' ''enabled'' is not defined'
+        when (attributes_std ->> 'enabled')::bool then ' default EBS encryption enabled'
         else ' default EBS encryption disabled'
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -46,13 +46,13 @@ query "ec2_ebs_default_encryption_enabled" {
 query "ec2_instance_detailed_monitoring_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'monitoring')::bool is true then 'ok'
+        when (attributes_std ->> 'monitoring')::bool is true then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'monitoring')::bool is true then ' detailed monitoring enabled'
+      address || case
+        when (attributes_std ->> 'monitoring')::bool is true then ' detailed monitoring enabled'
         else ' detailed monitoring disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -67,13 +67,13 @@ query "ec2_instance_detailed_monitoring_enabled" {
 query "ec2_instance_ebs_optimized" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'ebs_optimized')::bool is true then 'ok'
+        when (attributes_std -> 'ebs_optimized')::bool is true then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'ebs_optimized')::bool is true then ' EBS optimization enabled'
+      address || case
+        when (attributes_std -> 'ebs_optimized')::bool is true then ' EBS optimization enabled'
         else ' EBS optimization disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -88,13 +88,13 @@ query "ec2_instance_ebs_optimized" {
 query "ec2_instance_not_publicly_accessible" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'associate_public_ip_address') is null then 'ok'
+        when (attributes_std -> 'associate_public_ip_address') is null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'associate_public_ip_address') is null then ' not publicly accessible'
+      address || case
+        when (attributes_std -> 'associate_public_ip_address') is null then ' not publicly accessible'
         else ' publicly accessible'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -109,15 +109,15 @@ query "ec2_instance_not_publicly_accessible" {
 query "ec2_instance_not_use_default_vpc" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'subnet_id') is null then 'skip'
-        when split_part((arguments ->> 'subnet_id'), '.', 2) in (select name from terraform_resource where type = 'aws_subnet' and (arguments ->> 'vpc_id') like '%default%') then 'alarm'
+        when (attributes_std -> 'subnet_id') is null then 'skip'
+        when split_part((attributes_std ->> 'subnet_id'), '.', 2) in (select name from terraform_resource where type = 'aws_subnet' and (attributes_std ->> 'vpc_id') like '%default%') then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'subnet_id') is null then ' does not have a subnet id defined'
-        when split_part((arguments ->> 'subnet_id'), '.', 2) in (select name from terraform_resource where type = 'aws_subnet' and (arguments ->> 'vpc_id') like '%default%') then ' deployed to a default VPC'
+      address || case
+        when (attributes_std -> 'subnet_id') is null then ' does not have a subnet id defined'
+        when split_part((attributes_std ->> 'subnet_id'), '.', 2) in (select name from terraform_resource where type = 'aws_subnet' and (attributes_std ->> 'vpc_id') like '%default%') then ' deployed to a default VPC'
         else ' not deployed to a default VPC'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -132,16 +132,16 @@ query "ec2_instance_not_use_default_vpc" {
 query "ec2_instance_not_use_multiple_enis" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when jsonb_typeof(arguments -> 'network_interface') is null then 'skip'
-        when (jsonb_typeof(arguments -> 'network_interface'))::text = 'object' then 'ok'
+        when jsonb_typeof(attributes_std -> 'network_interface') is null then 'skip'
+        when (jsonb_typeof(attributes_std -> 'network_interface'))::text = 'object' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when jsonb_typeof(arguments -> 'network_interface') is null then ' has no ENI attached'
-        when (jsonb_typeof(arguments -> 'network_interface'))::text = 'object' then ' has 1 ENI attached'
-        else ' has ' || (jsonb_array_length(arguments -> 'network_interface')) || ' ENI(s) attached'
+      address || case
+        when jsonb_typeof(attributes_std -> 'network_interface') is null then ' has no ENI attached'
+        when (jsonb_typeof(attributes_std -> 'network_interface'))::text = 'object' then ' has 1 ENI attached'
+        else ' has ' || (jsonb_array_length(attributes_std -> 'network_interface')) || ' ENI(s) attached'
       end || '.' as reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}
@@ -155,13 +155,13 @@ query "ec2_instance_not_use_multiple_enis" {
 query "ec2_instance_termination_protection_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'root_block_device' ->> 'delete_on_termination')::bool is true then 'ok'
+        when (attributes_std -> 'root_block_device' ->> 'delete_on_termination')::bool is true then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'root_block_device' ->> 'delete_on_termination')::bool is true then ' instance termination protection enabled'
+      address || case
+        when (attributes_std -> 'root_block_device' ->> 'delete_on_termination')::bool is true then ' instance termination protection enabled'
         else ' instance termination protection disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -176,14 +176,14 @@ query "ec2_instance_termination_protection_enabled" {
 query "ec2_instance_uses_imdsv2" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when coalesce(trim(arguments -> 'metadata_options' ->> 'http_tokens'),'') in ('optional', '') then 'alarm'
+        when coalesce(trim(attributes_std -> 'metadata_options' ->> 'http_tokens'),'') in ('optional', '') then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'metadata_options' -> 'http_tokens') is null then ' ''http_tokens'' is not defined'
-        when (arguments -> 'metadata_options' ->> 'http_tokens') = 'optional'
+      address || case
+        when (attributes_std -> 'metadata_options' -> 'http_tokens') is null then ' ''http_tokens'' is not defined'
+        when (attributes_std -> 'metadata_options' ->> 'http_tokens') = 'optional'
         then ' not configured to use Instance Metadata Service Version 2 (IMDSv2)'
         else ' configured to use Instance Metadata Service Version 2 (IMDSv2)'
       end || '.' as reason
@@ -199,17 +199,17 @@ query "ec2_instance_uses_imdsv2" {
 query "ec2_instance_user_data_no_secrets" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'user_data') is null then 'skip'
-        when (arguments ->> 'user_data') like any (array ['%pass%', '%secret%','%token%','%key%'])
-          or (arguments ->> 'user_data') ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]' then 'alarm'
+        when (attributes_std ->> 'user_data') is null then 'skip'
+        when (attributes_std ->> 'user_data') like any (array ['%pass%', '%secret%','%token%','%key%'])
+          or (attributes_std ->> 'user_data') ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]' then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments ->> 'user_data') is null then ' no user data defined.'
-        when (arguments ->> 'user_data') like any (array ['%pass%', '%secret%','%token%','%key%'])
-          or (arguments ->> 'user_data') ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]' then ' potential secret found in user data.'
+      address || case
+        when (attributes_std ->> 'user_data') is null then ' no user data defined.'
+        when (attributes_std ->> 'user_data') like any (array ['%pass%', '%secret%','%token%','%key%'])
+          or (attributes_std ->> 'user_data') ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]' then ' potential secret found in user data.'
         else ' no secrets found in user data.'
       end as reason
       ${local.tag_dimensions_sql}
@@ -224,13 +224,13 @@ query "ec2_instance_user_data_no_secrets" {
 query "ec2_ami_imagebuilder_component_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is null then 'alarm'
+        when (attributes_std ->> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments ->> 'kms_key_id') is null then ' is not encrypted with CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is null then ' is not encrypted with CMK'
         else ' is encrypted with CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -245,13 +245,13 @@ query "ec2_ami_imagebuilder_component_encrypted_with_kms_cmk" {
 query "ec2_ami_imagebuilder_distribution_configuration_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'distribution' -> 'ami_distribution_configuration' ->> 'kms_key_id') is null then 'alarm'
+        when (attributes_std -> 'distribution' -> 'ami_distribution_configuration' ->> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'distribution' -> 'ami_distribution_configuration' ->> 'kms_key_id') is null then ' is not encrypted with CMK'
+      address || case
+        when (attributes_std -> 'distribution' -> 'ami_distribution_configuration' ->> 'kms_key_id') is null then ' is not encrypted with CMK'
         else ' is encrypted with CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -266,13 +266,13 @@ query "ec2_ami_imagebuilder_distribution_configuration_encrypted_with_kms_cmk" {
 query "ec2_ami_imagebuilder_image_recipe_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'block_device_mapping' -> 'ebs' ->> 'kms_key_id') is null or (arguments -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') <> 'true' or (arguments -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') is null then 'alarm'
+        when (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'kms_key_id') is null or (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') <> 'true' or (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'block_device_mapping' -> 'ebs' ->> 'kms_key_id') is null or (arguments -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') <> 'true' or (arguments -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') is null then ' is not encrypted with CMK'
+      address || case
+        when (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'kms_key_id') is null or (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') <> 'true' or (attributes_std -> 'block_device_mapping' -> 'ebs' ->> 'encrypted') is null then ' is not encrypted with CMK'
         else ' is encrypted with CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -287,13 +287,13 @@ query "ec2_ami_imagebuilder_image_recipe_encrypted_with_kms_cmk" {
 query "ec2_launch_template_metadata_hop_limit_check" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then 'alarm'
+        when (attributes_std -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then ' metadata response hop limit value is greater than 1'
+      address || case
+        when (attributes_std -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then ' metadata response hop limit value is greater than 1'
         else ' metadata response hop limit value is not less than 1'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -308,13 +308,13 @@ query "ec2_launch_template_metadata_hop_limit_check" {
 query "ec2_launch_configuration_metadata_hop_limit_check" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then 'alarm'
+        when (attributes_std -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then ' metadata response hop limit value is greater than 1'
+      address || case
+        when (attributes_std -> 'metadata_options' ->> 'http_put_response_hop_limit')::int > 1 then ' metadata response hop limit value is greater than 1'
         else ' metadata response hop limit value is less than 1'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -329,13 +329,13 @@ query "ec2_launch_configuration_metadata_hop_limit_check" {
 query "ec2_launch_configuration_ebs_encryption_check" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'root_block_device') is not null and ((arguments -> 'root_block_device' ->> 'encrypted') = 'true' or (arguments -> 'root_block_device' ->> 'snapshot_id') is not null) and (((arguments -> 'ebs_block_device') is not null and ((arguments -> 'ebs_block_device' ->> 'encrypted') = 'true' or (arguments -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((arguments -> 'ebs_block_device') is null))  then 'ok'
+        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'root_block_device') is not null and ((arguments -> 'root_block_device' ->> 'encrypted') = 'true' or (arguments -> 'root_block_device' ->> 'snapshot_id') is not null) and (((arguments -> 'ebs_block_device') is not null and ((arguments -> 'ebs_block_device' ->> 'encrypted') = 'true' or (arguments -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((arguments -> 'ebs_block_device') is null))  then ' is securely encrypted'
+      address || case
+        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then ' is securely encrypted'
         else ' is not securely encrypted'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -350,13 +350,13 @@ query "ec2_launch_configuration_ebs_encryption_check" {
 query "ec2_instance_ebs_encryption_check" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'root_block_device') is not null and ((arguments -> 'root_block_device' ->> 'encrypted') = 'true' or (arguments -> 'root_block_device' ->> 'snapshot_id') is not null) and (((arguments -> 'ebs_block_device') is not null and ((arguments -> 'ebs_block_device' ->> 'encrypted') = 'true' or (arguments -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((arguments -> 'ebs_block_device') is null))  then 'ok'
+        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'root_block_device') is not null and ((arguments -> 'root_block_device' ->> 'encrypted') = 'true' or (arguments -> 'root_block_device' ->> 'snapshot_id') is not null) and (((arguments -> 'ebs_block_device') is not null and ((arguments -> 'ebs_block_device' ->> 'encrypted') = 'true' or (arguments -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((arguments -> 'ebs_block_device') is null))  then ' is securely encrypted'
+      address || case
+        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then ' is securely encrypted'
         else ' is not securely encrypted'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -371,13 +371,13 @@ query "ec2_instance_ebs_encryption_check" {
 query "ec2_ami_copy_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'encrypted') = 'true' then 'ok'
+        when (attributes_std ->> 'encrypted') = 'true' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'encrypted') = 'true' then ' is encrypted'
+      address || case
+        when (attributes_std ->> 'encrypted') = 'true' then ' is encrypted'
         else ' is not encrypted'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -392,13 +392,13 @@ query "ec2_ami_copy_encryption_enabled" {
 query "ec2_ami_copy_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is not null then 'ok'
+        when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'kms_key_id') is not null then ' is encrypted with CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is not null then ' is encrypted with CMK'
         else ' is not encrypted with CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -413,13 +413,13 @@ query "ec2_ami_copy_encrypted_with_kms_cmk" {
 query "ec2_ami_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'ebs_block_device' ->> 'encrypted') = 'true' or (arguments -> 'ebs_block_device' ->> 'snapshot_id') is not null then 'ok'
+        when (attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'ebs_block_device' ->> 'encrypted') = 'true' or (arguments -> 'ebs_block_device' ->> 'snapshot_id') is not null then ' is encrypted'
+      address || case
+        when (attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null then ' is encrypted'
         else ' is not encrypted'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -434,19 +434,19 @@ query "ec2_ami_encryption_enabled" {
 query "ec2_ami_launch_permission_restricted" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'account_id') is not null then 'ok'
-        when (arguments -> 'group') is not null then 'info'
-        when (arguments -> 'organizational_arn') is not null then 'info'
-        when (arguments -> 'organizational_unit_arn') is not null then 'info'
+        when (attributes_std -> 'account_id') is not null then 'ok'
+        when (attributes_std -> 'group') is not null then 'info'
+        when (attributes_std -> 'organizational_arn') is not null then 'info'
+        when (attributes_std -> 'organizational_unit_arn') is not null then 'info'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'account_id') is not null then ' is restrictive to account(s)'
-        when (arguments -> 'group') is not null then ' is open to IAM group'
-        when (arguments -> 'organizational_arn') is not null then ' is open to organization'
-        when (arguments -> 'organizational_unit_arn') is not null then ' is open to organization unit'
+      address || case
+        when (attributes_std -> 'account_id') is not null then ' is restrictive to account(s)'
+        when (attributes_std -> 'group') is not null then ' is open to IAM group'
+        when (attributes_std -> 'organizational_arn') is not null then ' is open to organization'
+        when (attributes_std -> 'organizational_unit_arn') is not null then ' is open to organization unit'
         else ' is wide open'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/ec2.sp
+++ b/query/ec2.sp
@@ -331,11 +331,11 @@ query "ec2_launch_configuration_ebs_encryption_check" {
     select
       address as resource,
       case
-        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then 'ok'
+        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null)) then 'ok'
         else 'alarm'
       end as status,
       split_part(address, '.', 2) || case
-        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then ' is securely encrypted'
+        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null)) then ' is securely encrypted'
         else ' is not securely encrypted'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -352,11 +352,11 @@ query "ec2_instance_ebs_encryption_check" {
     select
       address as resource,
       case
-        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then 'ok'
+        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null)) then 'ok'
         else 'alarm'
       end as status,
       split_part(address, '.', 2) || case
-        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null))  then ' is securely encrypted'
+        when (attributes_std -> 'root_block_device') is not null and ((attributes_std -> 'root_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'root_block_device' ->> 'snapshot_id') is not null) and (((attributes_std -> 'ebs_block_device') is not null and ((attributes_std -> 'ebs_block_device' ->> 'encrypted') = 'true' or (attributes_std -> 'ebs_block_device' ->> 'snapshot_id') is not null)) or ((attributes_std -> 'ebs_block_device') is null)) then ' is securely encrypted'
         else ' is not securely encrypted'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/ecr.sp
+++ b/query/ecr.sp
@@ -1,18 +1,18 @@
 query "ecr_repository_encrypted_with_kms" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-          (arguments ->> 'encryption_configuration') is not null
-          and coalesce((arguments -> 'encryption_configuration' ->> 'encryption_type'), '') = 'KMS'
+          (attributes_std ->> 'encryption_configuration') is not null
+          and coalesce((attributes_std -> 'encryption_configuration' ->> 'encryption_type'), '') = 'KMS'
         then 'ok'
         else 'alarm'
       end as status,
-      name || case
+      address || case
         when
-          (arguments ->> 'encryption_configuration') is not null
-          and coalesce((arguments -> 'encryption_configuration' ->> 'encryption_type'), '') = 'KMS'
+          (attributes_std ->> 'encryption_configuration') is not null
+          and coalesce((attributes_std -> 'encryption_configuration' ->> 'encryption_type'), '') = 'KMS'
         then ' encrypted using KMS'
         else ' not encrypted using KMS'
       end || '.' as reason
@@ -28,13 +28,13 @@ query "ecr_repository_encrypted_with_kms" {
 query "ecr_repository_tags_immutable" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'image_tag_mutability')::text = 'IMMUTABLE' then 'ok'
+        when (attributes_std ->> 'image_tag_mutability')::text = 'IMMUTABLE' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'image_tag_mutability')::text = 'IMMUTABLE' then ' has immutable tags'
+      address || case
+        when (attributes_std ->> 'image_tag_mutability')::text = 'IMMUTABLE' then ' has immutable tags'
         else ' does not have immutable tags'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -49,13 +49,13 @@ query "ecr_repository_tags_immutable" {
 query "ecr_repository_use_image_scanning" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'image_scanning_configuration' ->> 'scan_on_push')::boolean then 'ok'
+        when (attributes_std -> 'image_scanning_configuration' ->> 'scan_on_push')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'image_scanning_configuration' ->> 'scan_on_push')::boolean then ' uses image scanning'
+      address || case
+        when (attributes_std -> 'image_scanning_configuration' ->> 'scan_on_push')::boolean then ' uses image scanning'
         else ' does not use image scanning'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -71,13 +71,13 @@ query "ecr_repository_policy_prohibit_public_access" {
   sql = <<-EOQ
     with ecr_non_public_policies as (
       select
-        distinct (type || ' ' || name ) as name
+        distinct (address ) as name
       from
         terraform_resource,
         jsonb_array_elements(
-          case when ((arguments ->> 'policy') = '')
+          case when ((attributes_std ->> 'policy') = '')
             then null
-            else ((arguments ->> 'policy')::jsonb -> 'Statement') end
+            else ((attributes_std ->> 'policy')::jsonb -> 'Statement') end
         ) as s
       where
         type = 'aws_ecr_repository_policy'
@@ -91,12 +91,12 @@ query "ecr_repository_policy_prohibit_public_access" {
     select
       type || ' ' || b.name as resource,
       case
-        when (arguments ->> 'policy') = '' then 'ok'
+        when (attributes_std ->> 'policy') = '' then 'ok'
         when d.name is not null then 'ok'
         else 'alarm'
       end status,
-       b.name || case
-        when (arguments ->> 'policy') = '' then ' no policy defined'
+       b.address || case
+        when (attributes_std ->> 'policy') = '' then ' no policy defined'
         when d.name is not null then ' not public'
         else ' public'
       end || '.' reason

--- a/query/ecs.sp
+++ b/query/ecs.sp
@@ -1,17 +1,17 @@
 query "ecs_cluster_container_insights_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-          (arguments -> 'setting' ->> 'name')::text = 'containerInsights'
-          and (arguments -> 'setting' ->> 'value')::text = 'enabled' then 'ok'
+          (attributes_std -> 'setting' ->> 'name')::text = 'containerInsights'
+          and (attributes_std -> 'setting' ->> 'value')::text = 'enabled' then 'ok'
         else 'alarm'
       end as status,
-      name || case
+      address || case
         when
-          (arguments -> 'setting' ->> 'name')::text = 'containerInsights'
-          and (arguments -> 'setting' ->> 'value')::text = 'enabled' then ' container insights enabled'
+          (attributes_std -> 'setting' ->> 'name')::text = 'containerInsights'
+          and (attributes_std -> 'setting' ->> 'value')::text = 'enabled' then ' container insights enabled'
         else ' container insights disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -26,13 +26,13 @@ query "ecs_cluster_container_insights_enabled" {
 query "ecs_task_definition_encryption_in_transit_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'volume' -> 'efs_volume_configuration' ->> 'transit_encryption')::text = 'ENABLED' then 'ok'
+        when (attributes_std -> 'volume' -> 'efs_volume_configuration' ->> 'transit_encryption')::text = 'ENABLED' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'volume' -> 'efs_volume_configuration' ->> 'transit_encryption')::text = 'ENABLED' then ' encryption in transit enabled'
+      address || case
+        when (attributes_std -> 'volume' -> 'efs_volume_configuration' ->> 'transit_encryption')::text = 'ENABLED' then ' encryption in transit enabled'
         else ' encryption in transit disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -47,13 +47,13 @@ query "ecs_task_definition_encryption_in_transit_enabled" {
 query "ecs_cluster_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') in ('DEFAULT','OVERRIDE') then 'ok'
+        when (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') in ('DEFAULT','OVERRIDE') then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') in ('DEFAULT','OVERRIDE') then ' logging enabled'
+      address || case
+        when (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') in ('DEFAULT','OVERRIDE') then ' logging enabled'
         else ' logging disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -68,14 +68,14 @@ query "ecs_cluster_logging_enabled" {
 query "ecs_cluster_logging_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') <> 'NONE' and (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'kms_key_id') is not null and ((arguments -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 'cloud_watch_encryption_enabled')::boolean or (arguments -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 's3_bucket_encryption_enabled')::boolean) then 'ok'
+        when (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') <> 'NONE' and (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'kms_key_id') is not null and ((attributes_std -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 'cloud_watch_encryption_enabled')::boolean or (attributes_std -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 's3_bucket_encryption_enabled')::boolean) then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') <> 'NONE' and (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'kms_key_id') is not null and ((arguments -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 'cloud_watch_encryption_enabled')::boolean or (arguments -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 's3_bucket_encryption_enabled')::boolean) then ' cluster logging encrypted with kms cmk'
-        when (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') = 'NONE' or (arguments -> 'configuration' -> 'execute_command_configuration' ->> 'logging') is null then ' cluster logging disabled'
+      address || case
+        when (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') <> 'NONE' and (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'kms_key_id') is not null and ((attributes_std -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 'cloud_watch_encryption_enabled')::boolean or (attributes_std -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 's3_bucket_encryption_enabled')::boolean) then ' cluster logging encrypted with kms cmk'
+        when (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') = 'NONE' or (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') is null then ' cluster logging disabled'
         else ' cluster logging not encrypted with kms cmk'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -90,17 +90,17 @@ query "ecs_cluster_logging_encrypted_with_kms_cmk" {
 query "ecs_task_definition_role_check" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'execution_role_arn') is null then 'skip'
-        when (arguments ->> 'task_role_arn') is null then 'skip'
-        when (arguments ->> 'execution_role_arn') is not null and (arguments ->> 'task_role_arn') is not null and (arguments ->> 'execution_role_arn') <> (arguments ->> 'task_role_arn') then 'ok'
+        when (attributes_std ->> 'execution_role_arn') is null then 'skip'
+        when (attributes_std ->> 'task_role_arn') is null then 'skip'
+        when (attributes_std ->> 'execution_role_arn') is not null and (attributes_std ->> 'task_role_arn') is not null and (attributes_std ->> 'execution_role_arn') <> (attributes_std ->> 'task_role_arn') then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'execution_role_arn') is null then ' execution_role_arn not set'
-        when (arguments ->> 'task_role_arn') is null then ' task_role_arn not set'
-        when (arguments ->> 'execution_role_arn') is not null and (arguments ->> 'task_role_arn') is not null and (arguments ->> 'execution_role_arn') <> (arguments ->> 'task_role_arn') then ' execution_role_arn and task_role_arn are different'
+      address || case
+        when (attributes_std ->> 'execution_role_arn') is null then ' execution_role_arn not set'
+        when (attributes_std ->> 'task_role_arn') is null then ' task_role_arn not set'
+        when (attributes_std ->> 'execution_role_arn') is not null and (attributes_std ->> 'task_role_arn') is not null and (attributes_std ->> 'execution_role_arn') <> (attributes_std ->> 'task_role_arn') then ' execution_role_arn and task_role_arn are different'
         else ' execution_role_arn and task_role_arn are the same'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -115,14 +115,14 @@ query "ecs_task_definition_role_check" {
 query "ecs_service_fargate_uses_latest_version" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'launch_type') = 'FARGATE' and (arguments ->> 'platform_version') = 'LATEST' then 'ok'
+        when (attributes_std ->> 'launch_type') = 'FARGATE' and (attributes_std ->> 'platform_version') = 'LATEST' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'launch_type') = 'FARGATE' and (arguments ->> 'platform_version') = 'LATEST' then ' fargate latest'
-        when (arguments ->> 'launch_type') = 'FARGATE' and (arguments ->> 'platform_version') <> 'LATEST' then ' fargate not latest'
+      address || case
+        when (attributes_std ->> 'launch_type') = 'FARGATE' and (attributes_std ->> 'platform_version') = 'LATEST' then ' fargate latest'
+        when (attributes_std ->> 'launch_type') = 'FARGATE' and (attributes_std ->> 'platform_version') <> 'LATEST' then ' fargate not latest'
         else ' not fargate'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -138,13 +138,13 @@ query "ecs_task_definition_no_host_pid_mode" {
   sql = <<-EOQ
     with task_with_host as (
       select
-        distinct (type || ' ' || name ) as name
+        distinct (address ) as name
       from
         terraform_resource,
         jsonb_array_elements(
-          case when ((arguments ->> 'container_definitions') = '')
+          case when ((attributes_std ->> 'container_definitions') = '')
             then null
-            else (arguments ->> 'container_definitions')::jsonb end
+            else (attributes_std ->> 'container_definitions')::jsonb end
         ) as s where s ->> 'pidMode' = 'host' and type = 'aws_ecs_task_definition'
       )
       select
@@ -171,13 +171,13 @@ query "ecs_task_definition_container_non_privileged" {
   sql = <<-EOQ
     with task_with_root_privilege as (
       select
-        distinct (type || ' ' || name ) as name
+        distinct (address ) as name
       from
         terraform_resource,
         jsonb_array_elements(
-          case when ((arguments ->> 'container_definitions') = '')
+          case when ((attributes_std ->> 'container_definitions') = '')
             then null
-            else (arguments ->> 'container_definitions')::jsonb end
+            else (attributes_std ->> 'container_definitions')::jsonb end
         ) as s where (s ->> 'privilege')::boolean and type = 'aws_ecs_task_definition'
       )
       select
@@ -204,13 +204,13 @@ query "ecs_task_definition_container_readonly_root_filesystem" {
   sql = <<-EOQ
     with task_with_readonly_root_filesystem as (
       select
-        distinct (type || ' ' || name ) as name
+        distinct (address ) as name
       from
         terraform_resource,
         jsonb_array_elements(
-          case when ((arguments ->> 'container_definitions') = '')
+          case when ((attributes_std ->> 'container_definitions') = '')
             then null
-            else (arguments ->> 'container_definitions')::jsonb end
+            else (attributes_std ->> 'container_definitions')::jsonb end
         ) as s where (s ->> 'ReadonlyRootFilesystem')::boolean and type = 'aws_ecs_task_definition'
       )
       select

--- a/query/ecs.sp
+++ b/query/ecs.sp
@@ -8,7 +8,7 @@ query "ecs_cluster_container_insights_enabled" {
           and (attributes_std -> 'setting' ->> 'value')::text = 'enabled' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when
           (attributes_std -> 'setting' ->> 'name')::text = 'containerInsights'
           and (attributes_std -> 'setting' ->> 'value')::text = 'enabled' then ' container insights enabled'
@@ -31,7 +31,7 @@ query "ecs_task_definition_encryption_in_transit_enabled" {
         when (attributes_std -> 'volume' -> 'efs_volume_configuration' ->> 'transit_encryption')::text = 'ENABLED' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'volume' -> 'efs_volume_configuration' ->> 'transit_encryption')::text = 'ENABLED' then ' encryption in transit enabled'
         else ' encryption in transit disabled'
       end || '.' reason
@@ -52,7 +52,7 @@ query "ecs_cluster_logging_enabled" {
         when (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') in ('DEFAULT','OVERRIDE') then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') in ('DEFAULT','OVERRIDE') then ' logging enabled'
         else ' logging disabled'
       end || '.' as reason
@@ -73,7 +73,7 @@ query "ecs_cluster_logging_encrypted_with_kms_cmk" {
         when (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') <> 'NONE' and (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'kms_key_id') is not null and ((attributes_std -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 'cloud_watch_encryption_enabled')::boolean or (attributes_std -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 's3_bucket_encryption_enabled')::boolean) then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') <> 'NONE' and (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'kms_key_id') is not null and ((attributes_std -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 'cloud_watch_encryption_enabled')::boolean or (attributes_std -> 'configuration' -> 'execute_command_configuration' -> 'log_configuration' ->> 's3_bucket_encryption_enabled')::boolean) then ' cluster logging encrypted with kms cmk'
         when (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') = 'NONE' or (attributes_std -> 'configuration' -> 'execute_command_configuration' ->> 'logging') is null then ' cluster logging disabled'
         else ' cluster logging not encrypted with kms cmk'
@@ -97,7 +97,7 @@ query "ecs_task_definition_role_check" {
         when (attributes_std ->> 'execution_role_arn') is not null and (attributes_std ->> 'task_role_arn') is not null and (attributes_std ->> 'execution_role_arn') <> (attributes_std ->> 'task_role_arn') then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'execution_role_arn') is null then ' execution_role_arn not set'
         when (attributes_std ->> 'task_role_arn') is null then ' task_role_arn not set'
         when (attributes_std ->> 'execution_role_arn') is not null and (attributes_std ->> 'task_role_arn') is not null and (attributes_std ->> 'execution_role_arn') <> (attributes_std ->> 'task_role_arn') then ' execution_role_arn and task_role_arn are different'
@@ -120,7 +120,7 @@ query "ecs_service_fargate_uses_latest_version" {
         when (attributes_std ->> 'launch_type') = 'FARGATE' and (attributes_std ->> 'platform_version') = 'LATEST' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'launch_type') = 'FARGATE' and (attributes_std ->> 'platform_version') = 'LATEST' then ' fargate latest'
         when (attributes_std ->> 'launch_type') = 'FARGATE' and (attributes_std ->> 'platform_version') <> 'LATEST' then ' fargate not latest'
         else ' not fargate'
@@ -148,12 +148,12 @@ query "ecs_task_definition_no_host_pid_mode" {
         ) as s where s ->> 'pidMode' = 'host' and type = 'aws_ecs_task_definition'
       )
       select
-        type || ' ' || r.name as resource,
+        r.address as resource,
         case
           when h.name is null then 'ok'
           else 'alarm'
         end status,
-        case
+        split_part(r.address, '.', 2) || case
           when h.name is null then ' shares the host process namespace'
           else ' does not share the host process namespace'
         end || '.' reason
@@ -161,7 +161,7 @@ query "ecs_task_definition_no_host_pid_mode" {
         ${local.common_dimensions_sql}
       from
         terraform_resource as r
-        left join task_with_host as h on h.name = concat(r.type || ' ' || r.name)
+        left join task_with_host as h on h.name = r.address
       where
         type = 'aws_ecs_task_definition';
   EOQ
@@ -181,12 +181,12 @@ query "ecs_task_definition_container_non_privileged" {
         ) as s where (s ->> 'privilege')::boolean and type = 'aws_ecs_task_definition'
       )
       select
-        type || ' ' || r.name as resource,
+        r.address as resource,
         case
           when p.name is null then 'ok'
           else 'alarm'
         end status,
-        case
+        split_part(r.address, '.', 2) || case
           when p.name is null then ' does not have elevated privileges'
           else ' has elevated privileges'
         end || '.' reason
@@ -194,7 +194,7 @@ query "ecs_task_definition_container_non_privileged" {
         ${local.common_dimensions_sql}
       from
         terraform_resource as r
-        left join task_with_root_privilege as p on p.name = concat(r.type || ' ' || r.name)
+        left join task_with_root_privilege as p on p.name = r.address
       where
         type = 'aws_ecs_task_definition';
   EOQ
@@ -214,12 +214,12 @@ query "ecs_task_definition_container_readonly_root_filesystem" {
         ) as s where (s ->> 'ReadonlyRootFilesystem')::boolean and type = 'aws_ecs_task_definition'
       )
       select
-        type || ' ' || r.name as resource,
+        r.address as resource,
         case
           when p.name is not null then 'ok'
           else 'alarm'
         end status,
-        case
+        split_part(r.address, '.', 2) || case
           when p.name is not null then ' containers limited to read-only access to root filesystems'
           else ' containers not limited to read-only access to root filesystems'
         end || '.' reason
@@ -227,7 +227,7 @@ query "ecs_task_definition_container_readonly_root_filesystem" {
         ${local.common_dimensions_sql}
       from
         terraform_resource as r
-        left join task_with_readonly_root_filesystem as p on p.name = concat(r.type || ' ' || r.name)
+        left join task_with_readonly_root_filesystem as p on p.name = r.address
       where
         type = 'aws_ecs_task_definition';
   EOQ

--- a/query/efs.sp
+++ b/query/efs.sp
@@ -1,12 +1,12 @@
 query "efs_file_system_automatic_backups_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when name in (select split_part((arguments ->> 'file_system_id')::text, '.', 2) from terraform_resource where type = 'aws_efs_backup_policy' and (arguments -> 'backup_policy' ->> 'status')::text = 'ENABLED') then 'ok' else 'alarm'
+        when name in (select split_part((attributes_std ->> 'file_system_id')::text, '.', 2) from terraform_resource where type = 'aws_efs_backup_policy' and (attributes_std -> 'backup_policy' ->> 'status')::text = 'ENABLED') then 'ok' else 'alarm'
       end as status,
-      name || case
-        when name in (select split_part((arguments ->> 'file_system_id')::text, '.', 2) from terraform_resource where type = 'aws_efs_backup_policy' and (arguments -> 'backup_policy' ->> 'status')::text = 'ENABLED') then ' backup policy enabled'
+      address || case
+        when name in (select split_part((attributes_std ->> 'file_system_id')::text, '.', 2) from terraform_resource where type = 'aws_efs_backup_policy' and (attributes_std -> 'backup_policy' ->> 'status')::text = 'ENABLED') then ' backup policy enabled'
         else ' backup policy disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -21,15 +21,15 @@ query "efs_file_system_automatic_backups_enabled" {
 query "efs_file_system_encrypt_data_at_rest" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encrypted') is null then 'alarm'
-        when (arguments ->> 'encrypted')::boolean then 'ok'
+        when (attributes_std -> 'encrypted') is null then 'alarm'
+        when (attributes_std ->> 'encrypted')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'encrypted') is null then ' ''encrypted'' is not defined'
-        when (arguments ->> 'encrypted')::boolean then ' encrypted at rest'
+      address || case
+        when (attributes_std -> 'encrypted') is null then ' ''encrypted'' is not defined'
+        when (attributes_std ->> 'encrypted')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -44,15 +44,15 @@ query "efs_file_system_encrypt_data_at_rest" {
 query "efs_access_point_has_user_identity" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'posix_user') is null then 'alarm'
-        when (arguments -> 'posix_user' -> 'gid') is not null then 'ok'
+        when (attributes_std -> 'posix_user') is null then 'alarm'
+        when (attributes_std -> 'posix_user' -> 'gid') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'posix_user') is null then ' ''posix_user'' is not defined'
-        when (arguments -> 'posix_user' -> 'gid') is not null then ' has user identity'
+      address || case
+        when (attributes_std -> 'posix_user') is null then ' ''posix_user'' is not defined'
+        when (attributes_std -> 'posix_user' -> 'gid') is not null then ' has user identity'
         else ' does not have user identity'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -67,15 +67,15 @@ query "efs_access_point_has_user_identity" {
 query "efs_access_point_has_root_directory" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'root_directory') is null then 'alarm'
-        when (arguments -> 'root_directory' -> 'path') is not null then 'ok'
+        when (attributes_std -> 'root_directory') is null then 'alarm'
+        when (attributes_std -> 'root_directory' -> 'path') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'root_directory') is null then ' ''root_directory'' is not defined'
-        when (arguments -> 'root_directory' -> 'path') is not null then ' has root directory'
+      address || case
+        when (attributes_std -> 'root_directory') is null then ' ''root_directory'' is not defined'
+        when (attributes_std -> 'root_directory' -> 'path') is not null then ' has root directory'
         else ' does not have root directory'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -90,13 +90,13 @@ query "efs_access_point_has_root_directory" {
 query "efs_file_system_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_id') is null then 'alarm'
+        when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kms_key_id') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/efs.sp
+++ b/query/efs.sp
@@ -5,7 +5,7 @@ query "efs_file_system_automatic_backups_enabled" {
       case
         when name in (select split_part((attributes_std ->> 'file_system_id')::text, '.', 2) from terraform_resource where type = 'aws_efs_backup_policy' and (attributes_std -> 'backup_policy' ->> 'status')::text = 'ENABLED') then 'ok' else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when name in (select split_part((attributes_std ->> 'file_system_id')::text, '.', 2) from terraform_resource where type = 'aws_efs_backup_policy' and (attributes_std -> 'backup_policy' ->> 'status')::text = 'ENABLED') then ' backup policy enabled'
         else ' backup policy disabled'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "efs_file_system_encrypt_data_at_rest" {
         when (attributes_std ->> 'encrypted')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encrypted') is null then ' ''encrypted'' is not defined'
         when (attributes_std ->> 'encrypted')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
@@ -50,7 +50,7 @@ query "efs_access_point_has_user_identity" {
         when (attributes_std -> 'posix_user' -> 'gid') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'posix_user') is null then ' ''posix_user'' is not defined'
         when (attributes_std -> 'posix_user' -> 'gid') is not null then ' has user identity'
         else ' does not have user identity'
@@ -73,7 +73,7 @@ query "efs_access_point_has_root_directory" {
         when (attributes_std -> 'root_directory' -> 'path') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'root_directory') is null then ' ''root_directory'' is not defined'
         when (attributes_std -> 'root_directory' -> 'path') is not null then ' has root directory'
         else ' does not have root directory'
@@ -95,7 +95,7 @@ query "efs_file_system_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason

--- a/query/eks.sp
+++ b/query/eks.sp
@@ -10,7 +10,7 @@ query "eks_cluster_endpoint_restrict_public_access" {
         when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access') is null and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') @> '["0.0.0.0/0"]' then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access') is null and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') is null then ' endpoint publicly accessible'
         when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access')::boolean and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') is null then ' endpoint publicly accessible'
         when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access')::boolean and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') @> '["0.0.0.0/0"]' then ' endpoint publicly accessible'
@@ -34,7 +34,7 @@ query "eks_cluster_log_types_enabled" {
         when (attributes_std -> 'enabled_cluster_log_types') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'enabled_cluster_log_types') is null then ' logging disabled'
         else ' logging enabled'
       end || '.' as reason
@@ -56,7 +56,7 @@ query "eks_cluster_secrets_encrypted" {
         when (attributes_std -> 'encryption_config' -> 'resources') @> '["secrets"]' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encryption_config') is null then ' encryption disabled'
         when (attributes_std -> 'encryption_config' -> 'resources') @> '["secrets"]' then ' encrypted with EKS secrets'
         else ' not encrypted with EKS secrets'
@@ -79,7 +79,7 @@ query "eks_cluster_run_on_supported_kubernetes_version" {
         when (attributes_std ->> 'version') like any (array ['1.22', '1.23', '1.24', '1.25', '1.26']) then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'version') is null then ' Kubernetes version not set'
         when (attributes_std ->> 'version') like any (array ['1.22', '1.23', '1.24', '1.25', '1.26']) then ' run on supported Kubernetes version'
         else ' do not run on supported Kubernetes version'
@@ -102,7 +102,7 @@ query "eks_cluster_control_plane_logging_enabled" {
         when (attributes_std ->> 'enabled_cluster_log_types') like '%["api", "authenticator", "audit", "scheduler", "controllerManager"]%' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'enabled_cluster_log_types') is null then ' control plane logging not set'
         when (attributes_std ->> 'enabled_cluster_log_types') like '%["api", "authenticator", "audit", "scheduler", "controllerManager"]%' then ' control plane logging enabled'
         else ' control plane logging disabled'
@@ -126,7 +126,7 @@ query "eks_cluster_node_group_ssh_access_from_internet" {
         when (attributes_std -> 'remote_access' ->> 'ec2_ssh_key') is not null and (attributes_std -> 'remote_access' ->> 'source_security_group_ids') is null then 'alarm'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'remote_access') is null then ' node group does not have implicit SSH access from 0.0.0.0/0'
         when (attributes_std -> 'remote_access' ->> 'ec2_ssh_key') is not null and (attributes_std -> 'remote_access' ->> 'source_security_group_ids') is not null then ' SSH access restricted to security group(s)'
         when (attributes_std -> 'remote_access' ->> 'ec2_ssh_key') is not null and (attributes_std -> 'remote_access' ->> 'source_security_group_ids') is null then ' has implicit SSH access from 0.0.0.0/0'

--- a/query/eks.sp
+++ b/query/eks.sp
@@ -1,20 +1,20 @@
 query "eks_cluster_endpoint_restrict_public_access" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         -- In case both endpoint_public_access & public_access_cidrs are not configured in vpc_config then default setting is true and public_access_cidrs accessible to internet
-        when (arguments -> 'vpc_config' ->> 'endpoint_public_access') is null and (arguments -> 'vpc_config' -> 'public_access_cidrs') is null then 'alarm'
-        when (arguments -> 'vpc_config' ->> 'endpoint_public_access')::boolean and (arguments -> 'vpc_config' -> 'public_access_cidrs') is null then 'alarm'
-        when (arguments -> 'vpc_config' ->> 'endpoint_public_access')::boolean and (arguments -> 'vpc_config' -> 'public_access_cidrs') @> '["0.0.0.0/0"]' then 'alarm'
-        when (arguments -> 'vpc_config' ->> 'endpoint_public_access') is null and (arguments -> 'vpc_config' -> 'public_access_cidrs') @> '["0.0.0.0/0"]' then 'alarm'
+        when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access') is null and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') is null then 'alarm'
+        when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access')::boolean and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') is null then 'alarm'
+        when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access')::boolean and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') @> '["0.0.0.0/0"]' then 'alarm'
+        when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access') is null and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') @> '["0.0.0.0/0"]' then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'vpc_config' ->> 'endpoint_public_access') is null and (arguments -> 'vpc_config' -> 'public_access_cidrs') is null then ' endpoint publicly accessible'
-        when (arguments -> 'vpc_config' ->> 'endpoint_public_access')::boolean and (arguments -> 'vpc_config' -> 'public_access_cidrs') is null then ' endpoint publicly accessible'
-        when (arguments -> 'vpc_config' ->> 'endpoint_public_access')::boolean and (arguments -> 'vpc_config' -> 'public_access_cidrs') @> '["0.0.0.0/0"]' then ' endpoint publicly accessible'
-        when (arguments -> 'vpc_config' ->> 'endpoint_public_access') is null and (arguments -> 'vpc_config' -> 'public_access_cidrs') @> '["0.0.0.0/0"]' then ' endpoint publicly accessible'
+      address || case
+        when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access') is null and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') is null then ' endpoint publicly accessible'
+        when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access')::boolean and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') is null then ' endpoint publicly accessible'
+        when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access')::boolean and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') @> '["0.0.0.0/0"]' then ' endpoint publicly accessible'
+        when (attributes_std -> 'vpc_config' ->> 'endpoint_public_access') is null and (attributes_std -> 'vpc_config' -> 'public_access_cidrs') @> '["0.0.0.0/0"]' then ' endpoint publicly accessible'
         else ' endpoint not publicly accessible'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -29,13 +29,13 @@ query "eks_cluster_endpoint_restrict_public_access" {
 query "eks_cluster_log_types_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'enabled_cluster_log_types') is null then 'alarm'
+        when (attributes_std -> 'enabled_cluster_log_types') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'enabled_cluster_log_types') is null then ' logging disabled'
+      address || case
+        when (attributes_std -> 'enabled_cluster_log_types') is null then ' logging disabled'
         else ' logging enabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -50,15 +50,15 @@ query "eks_cluster_log_types_enabled" {
 query "eks_cluster_secrets_encrypted" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encryption_config') is null then 'alarm'
-        when (arguments -> 'encryption_config' -> 'resources') @> '["secrets"]' then 'ok'
+        when (attributes_std -> 'encryption_config') is null then 'alarm'
+        when (attributes_std -> 'encryption_config' -> 'resources') @> '["secrets"]' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'encryption_config') is null then ' encryption disabled'
-        when (arguments -> 'encryption_config' -> 'resources') @> '["secrets"]' then ' encrypted with EKS secrets'
+      address || case
+        when (attributes_std -> 'encryption_config') is null then ' encryption disabled'
+        when (attributes_std -> 'encryption_config' -> 'resources') @> '["secrets"]' then ' encrypted with EKS secrets'
         else ' not encrypted with EKS secrets'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -73,15 +73,15 @@ query "eks_cluster_secrets_encrypted" {
 query "eks_cluster_run_on_supported_kubernetes_version" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'version') is null then 'skip'
-        when (arguments ->> 'version') like any (array ['1.22', '1.23', '1.24', '1.25', '1.26']) then 'ok'
+        when (attributes_std ->> 'version') is null then 'skip'
+        when (attributes_std ->> 'version') like any (array ['1.22', '1.23', '1.24', '1.25', '1.26']) then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'version') is null then ' Kubernetes version not set'
-        when (arguments ->> 'version') like any (array ['1.22', '1.23', '1.24', '1.25', '1.26']) then ' run on supported Kubernetes version'
+      address || case
+        when (attributes_std ->> 'version') is null then ' Kubernetes version not set'
+        when (attributes_std ->> 'version') like any (array ['1.22', '1.23', '1.24', '1.25', '1.26']) then ' run on supported Kubernetes version'
         else ' do not run on supported Kubernetes version'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -96,15 +96,15 @@ query "eks_cluster_run_on_supported_kubernetes_version" {
 query "eks_cluster_control_plane_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'enabled_cluster_log_types') is null then 'alarm'
-        when (arguments ->> 'enabled_cluster_log_types') like '%["api", "authenticator", "audit", "scheduler", "controllerManager"]%' then 'ok'
+        when (attributes_std -> 'enabled_cluster_log_types') is null then 'alarm'
+        when (attributes_std ->> 'enabled_cluster_log_types') like '%["api", "authenticator", "audit", "scheduler", "controllerManager"]%' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'enabled_cluster_log_types') is null then ' control plane logging not set'
-        when (arguments ->> 'enabled_cluster_log_types') like '%["api", "authenticator", "audit", "scheduler", "controllerManager"]%' then ' control plane logging enabled'
+      address || case
+        when (attributes_std -> 'enabled_cluster_log_types') is null then ' control plane logging not set'
+        when (attributes_std ->> 'enabled_cluster_log_types') like '%["api", "authenticator", "audit", "scheduler", "controllerManager"]%' then ' control plane logging enabled'
         else ' control plane logging disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -119,17 +119,17 @@ query "eks_cluster_control_plane_logging_enabled" {
 query "eks_cluster_node_group_ssh_access_from_internet" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'remote_access') is null then 'ok'
-        when (arguments -> 'remote_access' ->> 'ec2_ssh_key') is not null and (arguments -> 'remote_access' ->> 'source_security_group_ids') is not null then 'ok'
-        when (arguments -> 'remote_access' ->> 'ec2_ssh_key') is not null and (arguments -> 'remote_access' ->> 'source_security_group_ids') is null then 'alarm'
+        when (attributes_std -> 'remote_access') is null then 'ok'
+        when (attributes_std -> 'remote_access' ->> 'ec2_ssh_key') is not null and (attributes_std -> 'remote_access' ->> 'source_security_group_ids') is not null then 'ok'
+        when (attributes_std -> 'remote_access' ->> 'ec2_ssh_key') is not null and (attributes_std -> 'remote_access' ->> 'source_security_group_ids') is null then 'alarm'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'remote_access') is null then ' node group does not have implicit SSH access from 0.0.0.0/0'
-        when (arguments -> 'remote_access' ->> 'ec2_ssh_key') is not null and (arguments -> 'remote_access' ->> 'source_security_group_ids') is not null then ' SSH access restricted to security group(s)'
-        when (arguments -> 'remote_access' ->> 'ec2_ssh_key') is not null and (arguments -> 'remote_access' ->> 'source_security_group_ids') is null then ' has implicit SSH access from 0.0.0.0/0'
+      address || case
+        when (attributes_std -> 'remote_access') is null then ' node group does not have implicit SSH access from 0.0.0.0/0'
+        when (attributes_std -> 'remote_access' ->> 'ec2_ssh_key') is not null and (attributes_std -> 'remote_access' ->> 'source_security_group_ids') is not null then ' SSH access restricted to security group(s)'
+        when (attributes_std -> 'remote_access' ->> 'ec2_ssh_key') is not null and (attributes_std -> 'remote_access' ->> 'source_security_group_ids') is null then ' has implicit SSH access from 0.0.0.0/0'
         else ' has implicit SSH access from 0.0.0.0/0'
         end || '.' reason
         ${local.tag_dimensions_sql}

--- a/query/elasticache.sp
+++ b/query/elasticache.sp
@@ -1,14 +1,14 @@
 query "elasticache_redis_cluster_automatic_backup_retention_15_days" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'snapshot_retention_limit')::int < 15 then 'alarm'
+        when (attributes_std -> 'snapshot_retention_limit')::int < 15 then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'snapshot_retention_limit')::int is null then ' automatic backups disabled'
-        when (arguments -> 'snapshot_retention_limit')::int < 15 then ' automatic backup retention period is less than 15 days'
+      address || case
+        when (attributes_std -> 'snapshot_retention_limit')::int is null then ' automatic backups disabled'
+        when (attributes_std -> 'snapshot_retention_limit')::int < 15 then ' automatic backup retention period is less than 15 days'
         else ' automatic backup retention period is more than 15 days'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -23,13 +23,13 @@ query "elasticache_redis_cluster_automatic_backup_retention_15_days" {
 query "elasticache_replication_group_encryption_in_transit_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'transit_encryption_enabled')::boolean then 'ok'
+        when (attributes_std ->> 'transit_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'transit_encryption_enabled')::boolean then ' encrypted in transit'
+      address || case
+        when (attributes_std ->> 'transit_encryption_enabled')::boolean then ' encrypted in transit'
         else ' not encrypted in transit'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -44,15 +44,15 @@ query "elasticache_replication_group_encryption_in_transit_enabled" {
 query "elasticache_replication_group_encryption_in_transit_enabled_auth_token" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'transit_encryption_enabled')::boolean and (arguments ->> 'auth_token') is not null then 'ok'
+        when (attributes_std ->> 'transit_encryption_enabled')::boolean and (attributes_std ->> 'auth_token') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'transit_encryption_enabled')::boolean and (arguments ->> 'auth_token') is not null then ' encrypted in transit and auth token set'
-        when (arguments ->> 'transit_encryption_enabled')::boolean and (arguments ->> 'auth_token') is null then ' encrypted in transit but auth token not set'
-        when (arguments ->> 'auth_token') is not null then 'not encrypted in transit but auth token set'
+      address || case
+        when (attributes_std ->> 'transit_encryption_enabled')::boolean and (attributes_std ->> 'auth_token') is not null then ' encrypted in transit and auth token set'
+        when (attributes_std ->> 'transit_encryption_enabled')::boolean and (attributes_std ->> 'auth_token') is null then ' encrypted in transit but auth token not set'
+        when (attributes_std ->> 'auth_token') is not null then 'not encrypted in transit but auth token set'
         else ' not encrypted in transit and auth token not set'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -67,13 +67,13 @@ query "elasticache_replication_group_encryption_in_transit_enabled_auth_token" {
 query "elasticache_replication_group_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'at_rest_encryption_enabled')::boolean then 'ok'
+        when (attributes_std ->> 'at_rest_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'at_rest_encryption_enabled')::boolean then ' encrypted at rest'
+      address || case
+        when (attributes_std ->> 'at_rest_encryption_enabled')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -88,13 +88,13 @@ query "elasticache_replication_group_encryption_at_rest_enabled" {
 query "elasticache_replication_group_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is not null then 'ok'
+        when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'kms_key_id') is not null then ' encrypted with kms cmk'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with kms cmk'
         else ' not encrypted with kms cmk'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -109,13 +109,13 @@ query "elasticache_replication_group_encrypted_with_kms_cmk" {
 query "elasticache_redis_cluster_auto_minor_version_upgrade" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'auto_minor_version_upgrade')::boolean then 'ok'
+        when (attributes_std ->> 'auto_minor_version_upgrade')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'auto_minor_version_upgrade')::boolean then ' auto minor version upgrade enabled'
+      address || case
+        when (attributes_std ->> 'auto_minor_version_upgrade')::boolean then ' auto minor version upgrade enabled'
         else ' auto minor version upgrade disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -130,13 +130,13 @@ query "elasticache_redis_cluster_auto_minor_version_upgrade" {
 query "elasticache_cluster_has_subnet_group" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'subnet_group_name') is not null then 'ok'
+        when (attributes_std ->> 'subnet_group_name') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'subnet_group_name') is not null then ' subnet group name set'
+      address || case
+        when (attributes_std ->> 'subnet_group_name') is not null then ' subnet group name set'
         else ' subnet group name not set'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/elasticache.sp
+++ b/query/elasticache.sp
@@ -6,7 +6,7 @@ query "elasticache_redis_cluster_automatic_backup_retention_15_days" {
         when (attributes_std -> 'snapshot_retention_limit')::int < 15 then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'snapshot_retention_limit')::int is null then ' automatic backups disabled'
         when (attributes_std -> 'snapshot_retention_limit')::int < 15 then ' automatic backup retention period is less than 15 days'
         else ' automatic backup retention period is more than 15 days'
@@ -28,7 +28,7 @@ query "elasticache_replication_group_encryption_in_transit_enabled" {
         when (attributes_std ->> 'transit_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'transit_encryption_enabled')::boolean then ' encrypted in transit'
         else ' not encrypted in transit'
       end || '.' as reason
@@ -49,7 +49,7 @@ query "elasticache_replication_group_encryption_in_transit_enabled_auth_token" {
         when (attributes_std ->> 'transit_encryption_enabled')::boolean and (attributes_std ->> 'auth_token') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'transit_encryption_enabled')::boolean and (attributes_std ->> 'auth_token') is not null then ' encrypted in transit and auth token set'
         when (attributes_std ->> 'transit_encryption_enabled')::boolean and (attributes_std ->> 'auth_token') is null then ' encrypted in transit but auth token not set'
         when (attributes_std ->> 'auth_token') is not null then 'not encrypted in transit but auth token set'
@@ -72,7 +72,7 @@ query "elasticache_replication_group_encryption_at_rest_enabled" {
         when (attributes_std ->> 'at_rest_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'at_rest_encryption_enabled')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason
@@ -93,7 +93,7 @@ query "elasticache_replication_group_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with kms cmk'
         else ' not encrypted with kms cmk'
       end || '.' as reason
@@ -114,7 +114,7 @@ query "elasticache_redis_cluster_auto_minor_version_upgrade" {
         when (attributes_std ->> 'auto_minor_version_upgrade')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'auto_minor_version_upgrade')::boolean then ' auto minor version upgrade enabled'
         else ' auto minor version upgrade disabled'
       end || '.' as reason
@@ -135,7 +135,7 @@ query "elasticache_cluster_has_subnet_group" {
         when (attributes_std ->> 'subnet_group_name') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'subnet_group_name') is not null then ' subnet group name set'
         else ' subnet group name not set'
       end || '.' as reason

--- a/query/elasticbeanstalk.sp
+++ b/query/elasticbeanstalk.sp
@@ -7,7 +7,7 @@ query "elasticbeanstalk_environment_use_managed_updates" {
         when jsonb_typeof(attributes_std -> 'setting') = 'object' and (attributes_std -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (attributes_std -> 'setting' ->> 'name') = 'ManagedActionsEnabled' and (attributes_std -> 'setting' ->> 'value')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when jsonb_typeof(attributes_std -> 'setting') = 'array' and exists(select 1 from jsonb_array_elements(attributes_std -> 'setting') as setting where (setting ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (setting ->> 'name') = 'ManagedActionsEnabled' and (setting ->> 'value')::boolean) then ' managed updates enabled'
         when jsonb_typeof(attributes_std -> 'setting') = 'object' and (attributes_std -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (attributes_std -> 'setting' ->> 'name') = 'ManagedActionsEnabled' and (attributes_std -> 'setting' ->> 'value')::boolean then ' managed updates enabled'
         else ' managed updates disabled'
@@ -30,7 +30,7 @@ query "elasticbeanstalk_environment_use_enhanced_health_checks" {
         when jsonb_typeof(attributes_std -> 'setting') = 'object' and (attributes_std -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (attributes_std -> 'setting' ->> 'name') = 'HealthStreamingEnabled' and (attributes_std -> 'setting' ->> 'value')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when jsonb_typeof(attributes_std -> 'setting') = 'array' and exists(select 1 from jsonb_array_elements(attributes_std -> 'setting') as setting where (setting ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (setting ->> 'name') = 'HealthStreamingEnabled' and (setting ->> 'value')::boolean) then ' health streaming enabled'
         when jsonb_typeof(attributes_std -> 'setting') = 'object' and (attributes_std -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (attributes_std -> 'setting' ->> 'name') = 'HealthStreamingEnabled' and (attributes_std -> 'setting' ->> 'value')::boolean then ' health streaming enabled'
         else ' health streaming disabled'

--- a/query/elasticbeanstalk.sp
+++ b/query/elasticbeanstalk.sp
@@ -1,15 +1,15 @@
 query "elasticbeanstalk_environment_use_managed_updates" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when jsonb_typeof(arguments -> 'setting') = 'array' and exists(select 1 from jsonb_array_elements(arguments -> 'setting') as setting where (setting ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (setting ->> 'name') = 'ManagedActionsEnabled' and (setting ->> 'value')::boolean) then 'ok'
-        when jsonb_typeof(arguments -> 'setting') = 'object' and (arguments -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (arguments -> 'setting' ->> 'name') = 'ManagedActionsEnabled' and (arguments -> 'setting' ->> 'value')::boolean then 'ok'
+        when jsonb_typeof(attributes_std -> 'setting') = 'array' and exists(select 1 from jsonb_array_elements(attributes_std -> 'setting') as setting where (setting ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (setting ->> 'name') = 'ManagedActionsEnabled' and (setting ->> 'value')::boolean) then 'ok'
+        when jsonb_typeof(attributes_std -> 'setting') = 'object' and (attributes_std -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (attributes_std -> 'setting' ->> 'name') = 'ManagedActionsEnabled' and (attributes_std -> 'setting' ->> 'value')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when jsonb_typeof(arguments -> 'setting') = 'array' and exists(select 1 from jsonb_array_elements(arguments -> 'setting') as setting where (setting ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (setting ->> 'name') = 'ManagedActionsEnabled' and (setting ->> 'value')::boolean) then ' managed updates enabled'
-        when jsonb_typeof(arguments -> 'setting') = 'object' and (arguments -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (arguments -> 'setting' ->> 'name') = 'ManagedActionsEnabled' and (arguments -> 'setting' ->> 'value')::boolean then ' managed updates enabled'
+      address || case
+        when jsonb_typeof(attributes_std -> 'setting') = 'array' and exists(select 1 from jsonb_array_elements(attributes_std -> 'setting') as setting where (setting ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (setting ->> 'name') = 'ManagedActionsEnabled' and (setting ->> 'value')::boolean) then ' managed updates enabled'
+        when jsonb_typeof(attributes_std -> 'setting') = 'object' and (attributes_std -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:managedactions' and (attributes_std -> 'setting' ->> 'name') = 'ManagedActionsEnabled' and (attributes_std -> 'setting' ->> 'value')::boolean then ' managed updates enabled'
         else ' managed updates disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -24,15 +24,15 @@ query "elasticbeanstalk_environment_use_managed_updates" {
 query "elasticbeanstalk_environment_use_enhanced_health_checks" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when jsonb_typeof(arguments -> 'setting') = 'array' and exists(select 1 from jsonb_array_elements(arguments -> 'setting') as setting where (setting ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (setting ->> 'name') = 'HealthStreamingEnabled' and (setting ->> 'value')::boolean) then 'ok'
-        when jsonb_typeof(arguments -> 'setting') = 'object' and (arguments -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (arguments -> 'setting' ->> 'name') = 'HealthStreamingEnabled' and (arguments -> 'setting' ->> 'value')::boolean then 'ok'
+        when jsonb_typeof(attributes_std -> 'setting') = 'array' and exists(select 1 from jsonb_array_elements(attributes_std -> 'setting') as setting where (setting ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (setting ->> 'name') = 'HealthStreamingEnabled' and (setting ->> 'value')::boolean) then 'ok'
+        when jsonb_typeof(attributes_std -> 'setting') = 'object' and (attributes_std -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (attributes_std -> 'setting' ->> 'name') = 'HealthStreamingEnabled' and (attributes_std -> 'setting' ->> 'value')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when jsonb_typeof(arguments -> 'setting') = 'array' and exists(select 1 from jsonb_array_elements(arguments -> 'setting') as setting where (setting ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (setting ->> 'name') = 'HealthStreamingEnabled' and (setting ->> 'value')::boolean) then ' health streaming enabled'
-        when jsonb_typeof(arguments -> 'setting') = 'object' and (arguments -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (arguments -> 'setting' ->> 'name') = 'HealthStreamingEnabled' and (arguments -> 'setting' ->> 'value')::boolean then ' health streaming enabled'
+      address || case
+        when jsonb_typeof(attributes_std -> 'setting') = 'array' and exists(select 1 from jsonb_array_elements(attributes_std -> 'setting') as setting where (setting ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (setting ->> 'name') = 'HealthStreamingEnabled' and (setting ->> 'value')::boolean) then ' health streaming enabled'
+        when jsonb_typeof(attributes_std -> 'setting') = 'object' and (attributes_std -> 'setting' ->> 'namespace') = 'aws:elasticbeanstalk:healthreporting:system' and (attributes_std -> 'setting' ->> 'name') = 'HealthStreamingEnabled' and (attributes_std -> 'setting' ->> 'value')::boolean then ' health streaming enabled'
         else ' health streaming disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/elb.sp
+++ b/query/elb.sp
@@ -11,7 +11,7 @@ query "elb_application_classic_network_lb_logging_enabled" {
         when (attributes_std -> 'access_logs' -> 'enabled')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'load_balancer_type') = 'gateway' then ' load balancer is of ' || (attributes_std ->> 'load_balancer_type') || ' type'
         when (attributes_std -> 'access_logs') is null then ' logging disabled'
         when (attributes_std -> 'access_logs' -> 'enabled')::bool then ' logging enabled'
@@ -33,7 +33,7 @@ query "elb_application_classic_network_lb_logging_enabled" {
         when (attributes_std -> 'access_logs' -> 'enabled')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'access_logs') is null then ' logging disabled'
         when (attributes_std -> 'access_logs' -> 'enabled')::bool then ' logging enabled'
         else ' logging disabled'
@@ -57,7 +57,7 @@ query "elb_application_lb_deletion_protection_enabled" {
         when (attributes_std -> 'enable_deletion_protection')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'enable_deletion_protection') is null then ' ''enable_deletion_protection'' not defined'
         when (attributes_std -> 'enable_deletion_protection')::boolean then ' deletion protection enabled'
         else ' deletion protection disabled'
@@ -80,7 +80,7 @@ query "elb_application_lb_drop_http_headers" {
         when (attributes_std -> 'drop_invalid_header_fields')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'drop_invalid_header_fields') is null then ' ''drop_invalid_header_fields'' disabled'
         when (attributes_std -> 'drop_invalid_header_fields')::boolean then ' ''drop_invalid_header_fields'' enabled'
         else ' ''drop_invalid_header_fields'' disabled'
@@ -103,7 +103,7 @@ query "elb_application_lb_waf_enabled" {
         when (attributes_std -> 'enable_waf_fail_open')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'enable_waf_fail_open') is null then ' WAF disabled'
         when (attributes_std -> 'enable_waf_fail_open')::boolean then ' WAF enabled'
         else ' WAF disabled'
@@ -126,7 +126,7 @@ query "elb_classic_lb_cross_zone_load_balancing_enabled" {
         when (attributes_std -> 'cross_zone_load_balancing')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'cross_zone_load_balancing') is null then ' cross-zone load balancing enabled'
         when (attributes_std -> 'cross_zone_load_balancing')::boolean then ' cross-zone load balancing enabled'
         else ' cross-zone load balancing disabled'
@@ -150,7 +150,7 @@ query "elb_classic_lb_use_ssl_certificate" {
         when (attributes_std -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (attributes_std -> 'listener' ->> 'ssl_certificate_id') like 'arn:aws:acm%' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'listener') is null then ' has no listener'
         when (attributes_std -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (attributes_std -> 'listener' -> 'ssl_certificate_id') is null then ' does not use certificate provided by ACM'
         when (attributes_std -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (attributes_std -> 'listener' ->> 'ssl_certificate_id') like 'arn:aws:acm%' then ' uses certificates provided by ACM'
@@ -173,7 +173,7 @@ query "elb_classic_lb_use_tls_https_listeners" {
         when (attributes_std -> 'listener' ->> 'lb_protocol') like any (array ['HTTPS', 'TLS']) then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'listener' ->> 'lb_protocol') like any (array ['HTTPS', 'TLS']) then ' configured with ' || (attributes_std -> 'listener' ->> 'lb_protocol') || ' protocol'
         else ' not configured with HTTPS or TLS protocol'
         end || '.' reason
@@ -194,7 +194,7 @@ query "elb_application_network_gateway_lb_use_desync_mitigation_mode" {
         when (attributes_std ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then ' configured with ' || (attributes_std ->> 'desync_mitigation_mode') || ' mitigation mode'
         else ' not configured with defensive or strictest desync mitigation mode'
         end || '.' reason
@@ -215,7 +215,7 @@ query "elb_classic_lb_use_desync_mitigation_mode" {
         when (attributes_std ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then ' configured with ' || (attributes_std ->> 'desync_mitigation_mode') || ' mitigation mode'
         else ' not configured with defensive or strictest desync mitigation mode'
         end || '.' reason
@@ -240,7 +240,7 @@ query "elb_application_lb_drop_invalid_header_fields" {
         then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'load_balancer_type') like any (array ['gateway', 'network']) then ' load balancer is of ' || (attributes_std ->> 'load_balancer_type') || ' type'
         when (attributes_std ->> 'drop_invalid_header_fields')::boolean
         and ((attributes_std ->> 'load_balancer_type') is null or (attributes_std ->> 'load_balancer_type') = 'application')
@@ -265,7 +265,7 @@ query "elb_lb_use_secure_protocol_listener" {
         when (attributes_std -> 'default_action' ->> 'type') = 'redirect' and (attributes_std -> 'default_action' -> 'redirect' ->> 'protocol') = 'HTTPS' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'protocol') like any (array ['HTTPS', 'TLS', 'TCP', 'UDP', 'TCP_UDP']) then ' listener configured with ' || (attributes_std ->> 'protocol') || ' secure protocol'
         when (attributes_std -> 'default_action' ->> 'type') = 'redirect' and (attributes_std -> 'default_action' -> 'redirect' ->> 'protocol') = 'HTTPS' then ' listener configured with ' || (attributes_std -> 'default_action' ->> 'type') || ' and ' || (attributes_std -> 'default_action' -> 'redirect' ->> 'protocol') || ' secure protocol'
         else ' listener not configured with any secured protocol'
@@ -288,7 +288,7 @@ query "elb_application_network_gateway_lb_cross_zone_load_balancing_enabled" {
         when (attributes_std ->> 'load_balancer_type') like any (array ['gateway', 'network']) and (attributes_std -> 'enable_cross_zone_load_balancing')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'load_balancer_type') = 'application' and (attributes_std -> 'enable_cross_zone_load_balancing') is null then ' cross-zone load balancing enabled default for ' || (attributes_std ->> 'load_balancer_type') || ' type'
         when (attributes_std ->> 'load_balancer_type') like any (array ['gateway', 'network']) and (attributes_std -> 'enable_cross_zone_load_balancing')::boolean then ' cross-zone load balancing enabled for ' || (attributes_std ->> 'load_balancer_type') || ' type'
         else ' cross-zone load balancing disabled'
@@ -310,7 +310,7 @@ query "elb_lb_target_group_use_health_check" {
         when (attributes_std ->> 'protocol') like any (array ['HTTPS', 'HTTP']) and (attributes_std ->> 'health_check') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'protocol') like any (array ['HTTPS', 'HTTP']) and (attributes_std ->> 'health_check') is not null then ' target group configured with health check'
         else ' target group not configured with health check'
         end || '.' reason

--- a/query/elb.sp
+++ b/query/elb.sp
@@ -2,19 +2,19 @@ query "elb_application_classic_network_lb_logging_enabled" {
   sql = <<-EOQ
   (
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
       --The Gateway Load Balancer does not generate access logs since it is a transparent layer 3 load balancer that does not terminate flows.
       --Boolean to enable / disable access_logs. Defaults to false, even when bucket is specified.
-        when (arguments ->> 'load_balancer_type') = 'gateway' then 'skip'
-        when (arguments -> 'access_logs') is null then 'alarm'
-        when (arguments -> 'access_logs' -> 'enabled')::bool then 'ok'
+        when (attributes_std ->> 'load_balancer_type') = 'gateway' then 'skip'
+        when (attributes_std -> 'access_logs') is null then 'alarm'
+        when (attributes_std -> 'access_logs' -> 'enabled')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'load_balancer_type') = 'gateway' then ' load balancer is of ' || (arguments ->> 'load_balancer_type') || ' type'
-        when (arguments -> 'access_logs') is null then ' logging disabled'
-        when (arguments -> 'access_logs' -> 'enabled')::bool then ' logging enabled'
+      address || case
+        when (attributes_std ->> 'load_balancer_type') = 'gateway' then ' load balancer is of ' || (attributes_std ->> 'load_balancer_type') || ' type'
+        when (attributes_std -> 'access_logs') is null then ' logging disabled'
+        when (attributes_std -> 'access_logs' -> 'enabled')::bool then ' logging enabled'
         else ' logging disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -27,15 +27,15 @@ query "elb_application_classic_network_lb_logging_enabled" {
   union
   (
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'access_logs') is null then 'alarm'
-        when (arguments -> 'access_logs' -> 'enabled')::bool then 'ok'
+        when (attributes_std -> 'access_logs') is null then 'alarm'
+        when (attributes_std -> 'access_logs' -> 'enabled')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'access_logs') is null then ' logging disabled'
-        when (arguments -> 'access_logs' -> 'enabled')::bool then ' logging enabled'
+      address || case
+        when (attributes_std -> 'access_logs') is null then ' logging disabled'
+        when (attributes_std -> 'access_logs' -> 'enabled')::bool then ' logging enabled'
         else ' logging disabled'
         end || '.' reason
         ${local.tag_dimensions_sql}
@@ -51,15 +51,15 @@ query "elb_application_classic_network_lb_logging_enabled" {
 query "elb_application_lb_deletion_protection_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'enable_deletion_protection') is null then 'alarm'
-        when (arguments -> 'enable_deletion_protection')::boolean then 'ok'
+        when (attributes_std -> 'enable_deletion_protection') is null then 'alarm'
+        when (attributes_std -> 'enable_deletion_protection')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'enable_deletion_protection') is null then ' ''enable_deletion_protection'' not defined'
-        when (arguments -> 'enable_deletion_protection')::boolean then ' deletion protection enabled'
+      address || case
+        when (attributes_std -> 'enable_deletion_protection') is null then ' ''enable_deletion_protection'' not defined'
+        when (attributes_std -> 'enable_deletion_protection')::boolean then ' deletion protection enabled'
         else ' deletion protection disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -74,15 +74,15 @@ query "elb_application_lb_deletion_protection_enabled" {
 query "elb_application_lb_drop_http_headers" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'drop_invalid_header_fields') is null then 'alarm'
-        when (arguments -> 'drop_invalid_header_fields')::boolean then 'ok'
+        when (attributes_std -> 'drop_invalid_header_fields') is null then 'alarm'
+        when (attributes_std -> 'drop_invalid_header_fields')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'drop_invalid_header_fields') is null then ' ''drop_invalid_header_fields'' disabled'
-        when (arguments -> 'drop_invalid_header_fields')::boolean then ' ''drop_invalid_header_fields'' enabled'
+      address || case
+        when (attributes_std -> 'drop_invalid_header_fields') is null then ' ''drop_invalid_header_fields'' disabled'
+        when (attributes_std -> 'drop_invalid_header_fields')::boolean then ' ''drop_invalid_header_fields'' enabled'
         else ' ''drop_invalid_header_fields'' disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -97,15 +97,15 @@ query "elb_application_lb_drop_http_headers" {
 query "elb_application_lb_waf_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'enable_waf_fail_open') is null then 'alarm'
-        when (arguments -> 'enable_waf_fail_open')::boolean then 'ok'
+        when (attributes_std -> 'enable_waf_fail_open') is null then 'alarm'
+        when (attributes_std -> 'enable_waf_fail_open')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'enable_waf_fail_open') is null then ' WAF disabled'
-        when (arguments -> 'enable_waf_fail_open')::boolean then ' WAF enabled'
+      address || case
+        when (attributes_std -> 'enable_waf_fail_open') is null then ' WAF disabled'
+        when (attributes_std -> 'enable_waf_fail_open')::boolean then ' WAF enabled'
         else ' WAF disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -120,15 +120,15 @@ query "elb_application_lb_waf_enabled" {
 query "elb_classic_lb_cross_zone_load_balancing_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'cross_zone_load_balancing') is null then 'ok'
-        when (arguments -> 'cross_zone_load_balancing')::boolean then 'ok'
+        when (attributes_std -> 'cross_zone_load_balancing') is null then 'ok'
+        when (attributes_std -> 'cross_zone_load_balancing')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'cross_zone_load_balancing') is null then ' cross-zone load balancing enabled'
-        when (arguments -> 'cross_zone_load_balancing')::boolean then ' cross-zone load balancing enabled'
+      address || case
+        when (attributes_std -> 'cross_zone_load_balancing') is null then ' cross-zone load balancing enabled'
+        when (attributes_std -> 'cross_zone_load_balancing')::boolean then ' cross-zone load balancing enabled'
         else ' cross-zone load balancing disabled'
         end || '.' reason
       ${local.tag_dimensions_sql}
@@ -143,17 +143,17 @@ query "elb_classic_lb_cross_zone_load_balancing_enabled" {
 query "elb_classic_lb_use_ssl_certificate" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'listener') is null then 'skip'
-        when (arguments -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (arguments -> 'listener' -> 'ssl_certificate_id') is null then 'alarm'
-        when (arguments -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (arguments -> 'listener' ->> 'ssl_certificate_id') like 'arn:aws:acm%' then 'ok'
+        when (attributes_std -> 'listener') is null then 'skip'
+        when (attributes_std -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (attributes_std -> 'listener' -> 'ssl_certificate_id') is null then 'alarm'
+        when (attributes_std -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (attributes_std -> 'listener' ->> 'ssl_certificate_id') like 'arn:aws:acm%' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'listener') is null then ' has no listener'
-        when (arguments -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (arguments -> 'listener' -> 'ssl_certificate_id') is null then ' does not use certificate provided by ACM'
-        when (arguments -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (arguments -> 'listener' ->> 'ssl_certificate_id') like 'arn:aws:acm%' then ' uses certificates provided by ACM'
+      address || case
+        when (attributes_std -> 'listener') is null then ' has no listener'
+        when (attributes_std -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (attributes_std -> 'listener' -> 'ssl_certificate_id') is null then ' does not use certificate provided by ACM'
+        when (attributes_std -> 'listener' ->> 'lb_protocol') ilike 'SSL' and (attributes_std -> 'listener' ->> 'ssl_certificate_id') like 'arn:aws:acm%' then ' uses certificates provided by ACM'
         else ' does not use certificate provided by ACM'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -168,13 +168,13 @@ query "elb_classic_lb_use_ssl_certificate" {
 query "elb_classic_lb_use_tls_https_listeners" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'listener' ->> 'lb_protocol') like any (array ['HTTPS', 'TLS']) then 'ok'
+        when (attributes_std -> 'listener' ->> 'lb_protocol') like any (array ['HTTPS', 'TLS']) then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'listener' ->> 'lb_protocol') like any (array ['HTTPS', 'TLS']) then ' configured with ' || (arguments -> 'listener' ->> 'lb_protocol') || ' protocol'
+      address || case
+        when (attributes_std -> 'listener' ->> 'lb_protocol') like any (array ['HTTPS', 'TLS']) then ' configured with ' || (attributes_std -> 'listener' ->> 'lb_protocol') || ' protocol'
         else ' not configured with HTTPS or TLS protocol'
         end || '.' reason
       ${local.tag_dimensions_sql}
@@ -189,13 +189,13 @@ query "elb_classic_lb_use_tls_https_listeners" {
 query "elb_application_network_gateway_lb_use_desync_mitigation_mode" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then 'ok'
+        when (attributes_std ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then ' configured with ' || (arguments ->> 'desync_mitigation_mode') || ' mitigation mode'
+      address || case
+        when (attributes_std ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then ' configured with ' || (attributes_std ->> 'desync_mitigation_mode') || ' mitigation mode'
         else ' not configured with defensive or strictest desync mitigation mode'
         end || '.' reason
       ${local.tag_dimensions_sql}
@@ -210,13 +210,13 @@ query "elb_application_network_gateway_lb_use_desync_mitigation_mode" {
 query "elb_classic_lb_use_desync_mitigation_mode" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then 'ok'
+        when (attributes_std ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then ' configured with ' || (arguments ->> 'desync_mitigation_mode') || ' mitigation mode'
+      address || case
+        when (attributes_std ->> 'desync_mitigation_mode') like any (array ['defensive', 'strictest']) then ' configured with ' || (attributes_std ->> 'desync_mitigation_mode') || ' mitigation mode'
         else ' not configured with defensive or strictest desync mitigation mode'
         end || '.' reason
       ${local.tag_dimensions_sql}
@@ -233,17 +233,17 @@ query "elb_classic_lb_use_desync_mitigation_mode" {
 query "elb_application_lb_drop_invalid_header_fields" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'load_balancer_type') like any (array ['gateway', 'network']) then 'skip'
-        when (arguments ->> 'drop_invalid_header_fields')::boolean and ((arguments ->> 'load_balancer_type') is null or (arguments ->> 'load_balancer_type') = 'application')
+        when (attributes_std ->> 'load_balancer_type') like any (array ['gateway', 'network']) then 'skip'
+        when (attributes_std ->> 'drop_invalid_header_fields')::boolean and ((attributes_std ->> 'load_balancer_type') is null or (attributes_std ->> 'load_balancer_type') = 'application')
         then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'load_balancer_type') like any (array ['gateway', 'network']) then ' load balancer is of ' || (arguments ->> 'load_balancer_type') || ' type'
-        when (arguments ->> 'drop_invalid_header_fields')::boolean
-        and ((arguments ->> 'load_balancer_type') is null or (arguments ->> 'load_balancer_type') = 'application')
+      address || case
+        when (attributes_std ->> 'load_balancer_type') like any (array ['gateway', 'network']) then ' load balancer is of ' || (attributes_std ->> 'load_balancer_type') || ' type'
+        when (attributes_std ->> 'drop_invalid_header_fields')::boolean
+        and ((attributes_std ->> 'load_balancer_type') is null or (attributes_std ->> 'load_balancer_type') = 'application')
         then ' configured to drop invalid http header field(s)'
         else ' not configured to drop invalid http header field(s)'
         end || '.' reason
@@ -259,15 +259,15 @@ query "elb_application_lb_drop_invalid_header_fields" {
 query "elb_lb_use_secure_protocol_listener" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'protocol') like any (array ['HTTPS', 'TLS', 'TCP', 'UDP', 'TCP_UDP']) then 'ok'
-        when (arguments -> 'default_action' ->> 'type') = 'redirect' and (arguments -> 'default_action' -> 'redirect' ->> 'protocol') = 'HTTPS' then 'ok'
+        when (attributes_std ->> 'protocol') like any (array ['HTTPS', 'TLS', 'TCP', 'UDP', 'TCP_UDP']) then 'ok'
+        when (attributes_std -> 'default_action' ->> 'type') = 'redirect' and (attributes_std -> 'default_action' -> 'redirect' ->> 'protocol') = 'HTTPS' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'protocol') like any (array ['HTTPS', 'TLS', 'TCP', 'UDP', 'TCP_UDP']) then ' listener configured with ' || (arguments ->> 'protocol') || ' secure protocol'
-        when (arguments -> 'default_action' ->> 'type') = 'redirect' and (arguments -> 'default_action' -> 'redirect' ->> 'protocol') = 'HTTPS' then ' listener configured with ' || (arguments -> 'default_action' ->> 'type') || ' and ' || (arguments -> 'default_action' -> 'redirect' ->> 'protocol') || ' secure protocol'
+      address || case
+        when (attributes_std ->> 'protocol') like any (array ['HTTPS', 'TLS', 'TCP', 'UDP', 'TCP_UDP']) then ' listener configured with ' || (attributes_std ->> 'protocol') || ' secure protocol'
+        when (attributes_std -> 'default_action' ->> 'type') = 'redirect' and (attributes_std -> 'default_action' -> 'redirect' ->> 'protocol') = 'HTTPS' then ' listener configured with ' || (attributes_std -> 'default_action' ->> 'type') || ' and ' || (attributes_std -> 'default_action' -> 'redirect' ->> 'protocol') || ' secure protocol'
         else ' listener not configured with any secured protocol'
         end || '.' reason
       ${local.tag_dimensions_sql}
@@ -282,15 +282,15 @@ query "elb_lb_use_secure_protocol_listener" {
 query "elb_application_network_gateway_lb_cross_zone_load_balancing_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments ->> 'load_balancer_type') = 'application' or (arguments ->> 'load_balancer_type') is null) and (arguments -> 'enable_cross_zone_load_balancing') is null then 'ok'
-        when (arguments ->> 'load_balancer_type') like any (array ['gateway', 'network']) and (arguments -> 'enable_cross_zone_load_balancing')::boolean then 'ok'
+        when ((attributes_std ->> 'load_balancer_type') = 'application' or (attributes_std ->> 'load_balancer_type') is null) and (attributes_std -> 'enable_cross_zone_load_balancing') is null then 'ok'
+        when (attributes_std ->> 'load_balancer_type') like any (array ['gateway', 'network']) and (attributes_std -> 'enable_cross_zone_load_balancing')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'load_balancer_type') = 'application' and (arguments -> 'enable_cross_zone_load_balancing') is null then ' cross-zone load balancing enabled default for ' || (arguments ->> 'load_balancer_type') || ' type'
-        when (arguments ->> 'load_balancer_type') like any (array ['gateway', 'network']) and (arguments -> 'enable_cross_zone_load_balancing')::boolean then ' cross-zone load balancing enabled for ' || (arguments ->> 'load_balancer_type') || ' type'
+      address || case
+        when (attributes_std ->> 'load_balancer_type') = 'application' and (attributes_std -> 'enable_cross_zone_load_balancing') is null then ' cross-zone load balancing enabled default for ' || (attributes_std ->> 'load_balancer_type') || ' type'
+        when (attributes_std ->> 'load_balancer_type') like any (array ['gateway', 'network']) and (attributes_std -> 'enable_cross_zone_load_balancing')::boolean then ' cross-zone load balancing enabled for ' || (attributes_std ->> 'load_balancer_type') || ' type'
         else ' cross-zone load balancing disabled'
         end || '.' reason
       ${local.tag_dimensions_sql}
@@ -305,13 +305,13 @@ query "elb_application_network_gateway_lb_cross_zone_load_balancing_enabled" {
 query "elb_lb_target_group_use_health_check" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'protocol') like any (array ['HTTPS', 'HTTP']) and (arguments ->> 'health_check') is not null then 'ok'
+        when (attributes_std ->> 'protocol') like any (array ['HTTPS', 'HTTP']) and (attributes_std ->> 'health_check') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'protocol') like any (array ['HTTPS', 'HTTP']) and (arguments ->> 'health_check') is not null then ' target group configured with health check'
+      address || case
+        when (attributes_std ->> 'protocol') like any (array ['HTTPS', 'HTTP']) and (attributes_std ->> 'health_check') is not null then ' target group configured with health check'
         else ' target group not configured with health check'
         end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/emr.sp
+++ b/query/emr.sp
@@ -6,7 +6,7 @@ query "emr_cluster_kerberos_enabled" {
         when (attributes_std -> 'kerberos_attributes') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kerberos_attributes') is null then ' kerberos disabled'
         else ' kerberos enabled'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "emr_cluster_security_configuration_local_disk_encryption_enabled" {
         when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' ->> 'LocalDiskEncryptionConfiguration') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' ->> 'LocalDiskEncryptionConfiguration') is not null then ' local disk encryption enabled'
         else ' local disk encryption disabled'
       end || '.' as reason
@@ -48,7 +48,7 @@ query "emr_cluster_security_configuration_encryption_in_transit_enabled" {
         when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableInTransitEncryption')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableInTransitEncryption')::bool then ' encryption in transit enabled'
         else ' encryption in transit disabled'
       end || '.' as reason
@@ -69,7 +69,7 @@ query "emr_cluster_security_configuration_ebs_encryption_enabled" {
         when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'LocalDiskEncryptionConfiguration' ->> 'EnableEbsEncryption')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'LocalDiskEncryptionConfiguration' ->> 'EnableEbsEncryption')::bool then ' EBS encryption enabled'
         else ' EBS encryption disabled'
       end || '.' as reason
@@ -90,7 +90,7 @@ query "emr_cluster_security_configuration_encryption_uses_sse_kms" {
         when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'S3EncryptionConfiguration' ->> 'EncryptionMode') = 'SSE-KMS' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'S3EncryptionConfiguration' ->> 'EncryptionMode') = 'SSE-KMS' then ' encryption uses SSE-KMS'
         else ' encryption does not use SSE-KMS'
       end || '.' as reason

--- a/query/emr.sp
+++ b/query/emr.sp
@@ -1,13 +1,13 @@
 query "emr_cluster_kerberos_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kerberos_attributes') is null then 'alarm'
+        when (attributes_std -> 'kerberos_attributes') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kerberos_attributes') is null then ' kerberos disabled'
+      address || case
+        when (attributes_std -> 'kerberos_attributes') is null then ' kerberos disabled'
         else ' kerberos enabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "emr_cluster_kerberos_enabled" {
 query "emr_cluster_security_configuration_local_disk_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' ->> 'LocalDiskEncryptionConfiguration') is not null then 'ok'
+        when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' ->> 'LocalDiskEncryptionConfiguration') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' ->> 'LocalDiskEncryptionConfiguration') is not null then ' local disk encryption enabled'
+      address || case
+        when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' ->> 'LocalDiskEncryptionConfiguration') is not null then ' local disk encryption enabled'
         else ' local disk encryption disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -43,13 +43,13 @@ query "emr_cluster_security_configuration_local_disk_encryption_enabled" {
 query "emr_cluster_security_configuration_encryption_in_transit_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableInTransitEncryption')::bool then 'ok'
+        when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableInTransitEncryption')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableInTransitEncryption')::bool then ' encryption in transit enabled'
+      address || case
+        when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableInTransitEncryption')::bool then ' encryption in transit enabled'
         else ' encryption in transit disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -64,13 +64,13 @@ query "emr_cluster_security_configuration_encryption_in_transit_enabled" {
 query "emr_cluster_security_configuration_ebs_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'LocalDiskEncryptionConfiguration' ->> 'EnableEbsEncryption')::bool then 'ok'
+        when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'LocalDiskEncryptionConfiguration' ->> 'EnableEbsEncryption')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'LocalDiskEncryptionConfiguration' ->> 'EnableEbsEncryption')::bool then ' EBS encryption enabled'
+      address || case
+        when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'LocalDiskEncryptionConfiguration' ->> 'EnableEbsEncryption')::bool then ' EBS encryption enabled'
         else ' EBS encryption disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -85,13 +85,13 @@ query "emr_cluster_security_configuration_ebs_encryption_enabled" {
 query "emr_cluster_security_configuration_encryption_uses_sse_kms" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'S3EncryptionConfiguration' ->> 'EncryptionMode') = 'SSE-KMS' then 'ok'
+        when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'S3EncryptionConfiguration' ->> 'EncryptionMode') = 'SSE-KMS' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((arguments ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'S3EncryptionConfiguration' ->> 'EncryptionMode') = 'SSE-KMS' then ' encryption uses SSE-KMS'
+      address || case
+        when ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' ->> 'EnableAtRestEncryption')::bool and ((attributes_std ->> 'configuration')::jsonb -> 'EncryptionConfiguration' -> 'AtRestEncryptionConfiguration' -> 'S3EncryptionConfiguration' ->> 'EncryptionMode') = 'SSE-KMS' then ' encryption uses SSE-KMS'
         else ' encryption does not use SSE-KMS'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/es.sp
+++ b/query/es.sp
@@ -9,7 +9,7 @@ query "es_domain_audit_logging_enabled" {
         ((attributes_std -> 'log_publishing_options') @> '[{"log_type": "AUDIT_LOGS"}]') then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std -> 'log_publishing_options' ->> 'cloudwatch_log_group_arn') is not null and (attributes_std -> 'log_publishing_options' ->> 'log_type')::text = 'AUDIT_LOGS')
         or
         ((attributes_std -> 'log_publishing_options') @> '[{"log_type": "AUDIT_LOGS"}]') then ' audit logging enabled'
@@ -33,7 +33,7 @@ query "es_domain_data_nodes_min_3" {
         when (attributes_std -> 'cluster_config' -> 'zone_awareness_enabled')::bool and (attributes_std -> 'cluster_config' ->> 'instance_count')::int >= 3 then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'cluster_config' -> 'zone_awareness_enabled')::bool = false then ' zone awareness disabled'
         else ' has ' || (attributes_std -> 'cluster_config' ->> 'instance_count') || ' data node(s)'
       end || '.' reason
@@ -55,7 +55,7 @@ query "es_domain_dedicated_master_nodes_min_3" {
         when (attributes_std -> 'cluster_config' -> 'dedicated_master_enabled')::bool and (attributes_std -> 'cluster_config' ->> 'instance_count')::int >= 3 then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'cluster_config' -> 'dedicated_master_enabled')::bool = false then ' dedicated master nodes disabled'
         else ' has ' || (attributes_std -> 'cluster_config' ->> 'instance_count') || ' data node(s)'
       end || '.' reason
@@ -76,7 +76,7 @@ query "es_domain_encrypted_using_tls_1_2" {
         when (attributes_std -> 'domain_endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'domain_endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then ' encrypted using TLS 1.2'
         else ' not encrypted using TLS 1.2'
       end || '.' reason
@@ -97,7 +97,7 @@ query "es_domain_encryption_at_rest_enabled" {
         when (attributes_std -> 'encrypt_at_rest' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encrypt_at_rest' ->> 'enabled')::boolean then ' encryption at rest enabled'
         else ' encryption at rest disabled'
       end || '.' reason
@@ -120,7 +120,7 @@ query "es_domain_error_logging_enabled" {
         (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std -> 'log_publishing_options' ->> 'cloudwatch_log_group_arn') is not null
         and (attributes_std -> 'log_publishing_options' ->> 'log_type')::text = 'ES_APPLICATION_LOGS') or (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then ' error logging enabled'
         else ' error logging disabled'
@@ -142,7 +142,7 @@ query "es_domain_in_vpc" {
         when (attributes_std -> 'vpc_options' -> 'subnet_ids') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'vpc_options' -> 'subnet_ids') is not null then ' in VPC'
         else ' not in VPC'
       end || '.' reason
@@ -165,7 +165,7 @@ query "es_domain_logs_to_cloudwatch" {
         (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' and
         (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' and
         (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then ' logging enabled for search , index and error'
@@ -189,7 +189,7 @@ query "es_domain_node_to_node_encryption_enabled" {
         when (attributes_std -> 'node_to_node_encryption' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'node_to_node_encryption' ->> 'enabled')::boolean then ' node-to-node encryption enabled'
         else ' node-to-node encryption disabled'
       end || '.' reason
@@ -210,7 +210,7 @@ query "es_domain_use_default_security_group" {
         when (attributes_std -> 'vpc_options' ->> 'security_group_ids') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'vpc_options' ->> 'security_group_ids') is not null then ' default security group not set'
         else ' default security group set'
       end || '.' reason
@@ -231,7 +231,7 @@ query "es_domain_enforce_https" {
         when (attributes_std -> 'domain_endpoint_options' ->> 'enforce_https')::boolean or (attributes_std -> 'domain_endpoint_options') is null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'domain_endpoint_options' ->> 'enforce_https')::boolean or (attributes_std -> 'domain_endpoint_options') is null  then ' enforces HTTPS'
         else ' does not enforces HTTPS'
       end || '.' reason
@@ -252,7 +252,7 @@ query "es_domain_encrypted_with_kms_cmk" {
         when (attributes_std -> 'encrypt_at_rest' -> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encrypt_at_rest' -> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' reason

--- a/query/es.sp
+++ b/query/es.sp
@@ -1,18 +1,18 @@
 query "es_domain_audit_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments -> 'log_publishing_options' ->> 'cloudwatch_log_group_arn') is not null
-        and (arguments -> 'log_publishing_options' ->> 'log_type')::text = 'AUDIT_LOGS')
+        when ((attributes_std -> 'log_publishing_options' ->> 'cloudwatch_log_group_arn') is not null
+        and (attributes_std -> 'log_publishing_options' ->> 'log_type')::text = 'AUDIT_LOGS')
         or
-        ((arguments -> 'log_publishing_options') @> '[{"log_type": "AUDIT_LOGS"}]') then 'ok'
+        ((attributes_std -> 'log_publishing_options') @> '[{"log_type": "AUDIT_LOGS"}]') then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when ((arguments -> 'log_publishing_options' ->> 'cloudwatch_log_group_arn') is not null and (arguments -> 'log_publishing_options' ->> 'log_type')::text = 'AUDIT_LOGS')
+      address || case
+        when ((attributes_std -> 'log_publishing_options' ->> 'cloudwatch_log_group_arn') is not null and (attributes_std -> 'log_publishing_options' ->> 'log_type')::text = 'AUDIT_LOGS')
         or
-        ((arguments -> 'log_publishing_options') @> '[{"log_type": "AUDIT_LOGS"}]') then ' audit logging enabled'
+        ((attributes_std -> 'log_publishing_options') @> '[{"log_type": "AUDIT_LOGS"}]') then ' audit logging enabled'
         else ' audit logging disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -27,15 +27,15 @@ query "es_domain_audit_logging_enabled" {
 query "es_domain_data_nodes_min_3" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'cluster_config' -> 'zone_awareness_enabled')::bool = false then 'alarm'
-        when (arguments -> 'cluster_config' -> 'zone_awareness_enabled')::bool and (arguments -> 'cluster_config' ->> 'instance_count')::int >= 3 then 'ok'
+        when (attributes_std -> 'cluster_config' -> 'zone_awareness_enabled')::bool = false then 'alarm'
+        when (attributes_std -> 'cluster_config' -> 'zone_awareness_enabled')::bool and (attributes_std -> 'cluster_config' ->> 'instance_count')::int >= 3 then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'cluster_config' -> 'zone_awareness_enabled')::bool = false then ' zone awareness disabled'
-        else ' has ' || (arguments -> 'cluster_config' ->> 'instance_count') || ' data node(s)'
+      address || case
+        when (attributes_std -> 'cluster_config' -> 'zone_awareness_enabled')::bool = false then ' zone awareness disabled'
+        else ' has ' || (attributes_std -> 'cluster_config' ->> 'instance_count') || ' data node(s)'
       end || '.' reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}
@@ -49,15 +49,15 @@ query "es_domain_data_nodes_min_3" {
 query "es_domain_dedicated_master_nodes_min_3" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'cluster_config' -> 'dedicated_master_enabled')::bool = false then 'alarm'
-        when (arguments -> 'cluster_config' -> 'dedicated_master_enabled')::bool and (arguments -> 'cluster_config' ->> 'instance_count')::int >= 3 then 'ok'
+        when (attributes_std -> 'cluster_config' -> 'dedicated_master_enabled')::bool = false then 'alarm'
+        when (attributes_std -> 'cluster_config' -> 'dedicated_master_enabled')::bool and (attributes_std -> 'cluster_config' ->> 'instance_count')::int >= 3 then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'cluster_config' -> 'dedicated_master_enabled')::bool = false then ' dedicated master nodes disabled'
-        else ' has ' || (arguments -> 'cluster_config' ->> 'instance_count') || ' data node(s)'
+      address || case
+        when (attributes_std -> 'cluster_config' -> 'dedicated_master_enabled')::bool = false then ' dedicated master nodes disabled'
+        else ' has ' || (attributes_std -> 'cluster_config' ->> 'instance_count') || ' data node(s)'
       end || '.' reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}
@@ -71,13 +71,13 @@ query "es_domain_dedicated_master_nodes_min_3" {
 query "es_domain_encrypted_using_tls_1_2" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'domain_endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then 'ok'
+        when (attributes_std -> 'domain_endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'domain_endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then ' encrypted using TLS 1.2'
+      address || case
+        when (attributes_std -> 'domain_endpoint_options' ->> 'tls_security_policy') = 'Policy-Min-TLS-1-2-2019-07' then ' encrypted using TLS 1.2'
         else ' not encrypted using TLS 1.2'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -92,13 +92,13 @@ query "es_domain_encrypted_using_tls_1_2" {
 query "es_domain_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encrypt_at_rest' ->> 'enabled')::boolean then 'ok'
+        when (attributes_std -> 'encrypt_at_rest' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'encrypt_at_rest' ->> 'enabled')::boolean then ' encryption at rest enabled'
+      address || case
+        when (attributes_std -> 'encrypt_at_rest' ->> 'enabled')::boolean then ' encryption at rest enabled'
         else ' encryption at rest disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -113,16 +113,16 @@ query "es_domain_encryption_at_rest_enabled" {
 query "es_domain_error_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments -> 'log_publishing_options' ->> 'cloudwatch_log_group_arn') is not null
-        and (arguments -> 'log_publishing_options' ->> 'log_type')::text = 'ES_APPLICATION_LOGS') or
-        (arguments -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then 'ok'
+        when ((attributes_std -> 'log_publishing_options' ->> 'cloudwatch_log_group_arn') is not null
+        and (attributes_std -> 'log_publishing_options' ->> 'log_type')::text = 'ES_APPLICATION_LOGS') or
+        (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when ((arguments -> 'log_publishing_options' ->> 'cloudwatch_log_group_arn') is not null
-        and (arguments -> 'log_publishing_options' ->> 'log_type')::text = 'ES_APPLICATION_LOGS') or (arguments -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then ' error logging enabled'
+      address || case
+        when ((attributes_std -> 'log_publishing_options' ->> 'cloudwatch_log_group_arn') is not null
+        and (attributes_std -> 'log_publishing_options' ->> 'log_type')::text = 'ES_APPLICATION_LOGS') or (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then ' error logging enabled'
         else ' error logging disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -137,13 +137,13 @@ query "es_domain_error_logging_enabled" {
 query "es_domain_in_vpc" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'vpc_options' -> 'subnet_ids') is not null then 'ok'
+        when (attributes_std -> 'vpc_options' -> 'subnet_ids') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'vpc_options' -> 'subnet_ids') is not null then ' in VPC'
+      address || case
+        when (attributes_std -> 'vpc_options' -> 'subnet_ids') is not null then ' in VPC'
         else ' not in VPC'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -158,17 +158,17 @@ query "es_domain_in_vpc" {
 query "es_domain_logs_to_cloudwatch" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' and
-        (arguments -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' and
-        (arguments -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then 'ok'
+        when (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' and
+        (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' and
+        (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' and
-        (arguments -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' and
-        (arguments -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then ' logging enabled for search , index and error'
+      address || case
+        when (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' and
+        (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' and
+        (attributes_std -> 'log_publishing_options') @> '[{"log_type": "ES_APPLICATION_LOGS"}]' then ' logging enabled for search , index and error'
         else ' logging not enabled for all search, index and error'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -184,13 +184,13 @@ query "es_domain_logs_to_cloudwatch" {
 query "es_domain_node_to_node_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'node_to_node_encryption' ->> 'enabled')::boolean then 'ok'
+        when (attributes_std -> 'node_to_node_encryption' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'node_to_node_encryption' ->> 'enabled')::boolean then ' node-to-node encryption enabled'
+      address || case
+        when (attributes_std -> 'node_to_node_encryption' ->> 'enabled')::boolean then ' node-to-node encryption enabled'
         else ' node-to-node encryption disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -205,13 +205,13 @@ query "es_domain_node_to_node_encryption_enabled" {
 query "es_domain_use_default_security_group" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'vpc_options' ->> 'security_group_ids') is not null then 'ok'
+        when (attributes_std -> 'vpc_options' ->> 'security_group_ids') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'vpc_options' ->> 'security_group_ids') is not null then ' default security group not set'
+      address || case
+        when (attributes_std -> 'vpc_options' ->> 'security_group_ids') is not null then ' default security group not set'
         else ' default security group set'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -226,13 +226,13 @@ query "es_domain_use_default_security_group" {
 query "es_domain_enforce_https" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'domain_endpoint_options' ->> 'enforce_https')::boolean or (arguments -> 'domain_endpoint_options') is null then 'ok'
+        when (attributes_std -> 'domain_endpoint_options' ->> 'enforce_https')::boolean or (attributes_std -> 'domain_endpoint_options') is null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'domain_endpoint_options' ->> 'enforce_https')::boolean or (arguments -> 'domain_endpoint_options') is null  then ' enforces HTTPS'
+      address || case
+        when (attributes_std -> 'domain_endpoint_options' ->> 'enforce_https')::boolean or (attributes_std -> 'domain_endpoint_options') is null  then ' enforces HTTPS'
         else ' does not enforces HTTPS'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -247,13 +247,13 @@ query "es_domain_enforce_https" {
 query "es_domain_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encrypt_at_rest' -> 'kms_key_id') is not null then 'ok'
+        when (attributes_std -> 'encrypt_at_rest' -> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'encrypt_at_rest' -> 'kms_key_id') is not null then ' encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'encrypt_at_rest' -> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/es.sp
+++ b/query/es.sp
@@ -232,7 +232,7 @@ query "es_domain_enforce_https" {
         else 'alarm'
       end status,
       split_part(address, '.', 2) || case
-        when (attributes_std -> 'domain_endpoint_options' ->> 'enforce_https')::boolean or (attributes_std -> 'domain_endpoint_options') is null  then ' enforces HTTPS'
+        when (attributes_std -> 'domain_endpoint_options' ->> 'enforce_https')::boolean or (attributes_std -> 'domain_endpoint_options') is null then ' enforces HTTPS'
         else ' does not enforces HTTPS'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/eventbridge.sp
+++ b/query/eventbridge.sp
@@ -2,13 +2,13 @@
 query "eventbridge_scheduler_schedule_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_arn') is null then 'alarm'
+        when (attributes_std ->> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments ->> 'kms_key_arn') is null then ' is not encrypted with KMS CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_arn') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/eventbridge.sp
+++ b/query/eventbridge.sp
@@ -7,7 +7,7 @@ query "eventbridge_scheduler_schedule_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_arn') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason

--- a/query/fsx.sp
+++ b/query/fsx.sp
@@ -6,7 +6,7 @@ query "fsx_ontap_file_system_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
@@ -27,7 +27,7 @@ query "fsx_openzfs_file_system_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
@@ -48,7 +48,7 @@ query "fsx_windows_file_system_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
@@ -69,7 +69,7 @@ query "fsx_lustre_file_system_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason

--- a/query/fsx.sp
+++ b/query/fsx.sp
@@ -1,13 +1,13 @@
 query "fsx_ontap_file_system_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_id') is null then 'alarm'
+        when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "fsx_ontap_file_system_encrypted_with_kms_cmk" {
 query "fsx_openzfs_file_system_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_id') is null then 'alarm'
+        when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -43,13 +43,13 @@ query "fsx_openzfs_file_system_encrypted_with_kms_cmk" {
 query "fsx_windows_file_system_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_id') is null then 'alarm'
+        when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -64,13 +64,13 @@ query "fsx_windows_file_system_encrypted_with_kms_cmk" {
 query "fsx_lustre_file_system_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_id') is null then 'alarm'
+        when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/glacier.sp
+++ b/query/glacier.sp
@@ -21,13 +21,13 @@ query "glacier_vault_restrict_public_access" {
         )
     )
     select
-      type || ' ' || r.name as resource,
+      r.address as resource,
       case
         when (attributes_std ->> 'access_policy') = '' then 'ok'
         when p.name is null then 'ok'
         else 'alarm'
       end status,
-      r.address || case
+      split_part(r.address, '.', 2) || case
         when (attributes_std ->> 'access_policy') = '' then ' no policy defined'
         when p.name is  null then ' not publicly accessible'
         else ' publicly accessible'
@@ -36,7 +36,7 @@ query "glacier_vault_restrict_public_access" {
       ${local.common_dimensions_sql}
     from
       terraform_resource as r
-      left join glacier_vault_public_policies as p on p.name = concat(r.type || ' ' || r.name)
+      left join glacier_vault_public_policies as p on p.name = r.address
     where
       r.type = 'aws_glacier_vault';
   EOQ

--- a/query/glacier.sp
+++ b/query/glacier.sp
@@ -29,7 +29,7 @@ query "glacier_vault_restrict_public_access" {
       end status,
       split_part(r.address, '.', 2) || case
         when (attributes_std ->> 'access_policy') = '' then ' no policy defined'
-        when p.name is  null then ' not publicly accessible'
+        when p.name is null then ' not publicly accessible'
         else ' publicly accessible'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/glacier.sp
+++ b/query/glacier.sp
@@ -2,13 +2,13 @@ query "glacier_vault_restrict_public_access" {
   sql = <<-EOQ
     with glacier_vault_public_policies as (
       select
-        distinct (type || ' ' || name ) as name
+        distinct (address ) as name
       from
         terraform_resource,
         jsonb_array_elements(
-          case when ((arguments ->> 'access_policy') = '')
+          case when ((attributes_std ->> 'access_policy') = '')
             then null
-            else ((arguments ->> 'access_policy')::jsonb -> 'Statement') end
+            else ((attributes_std ->> 'access_policy')::jsonb -> 'Statement') end
         ) as s
       where
         type = 'aws_glacier_vault'
@@ -23,12 +23,12 @@ query "glacier_vault_restrict_public_access" {
     select
       type || ' ' || r.name as resource,
       case
-        when (arguments ->> 'access_policy') = '' then 'ok'
+        when (attributes_std ->> 'access_policy') = '' then 'ok'
         when p.name is null then 'ok'
         else 'alarm'
       end status,
-      r.name || case
-        when (arguments ->> 'access_policy') = '' then ' no policy defined'
+      r.address || case
+        when (attributes_std ->> 'access_policy') = '' then ' no policy defined'
         when p.name is  null then ' not publicly accessible'
         else ' publicly accessible'
       end || '.' reason

--- a/query/globalaccelerator.sp
+++ b/query/globalaccelerator.sp
@@ -1,17 +1,17 @@
 query "globalaccelerator_flow_logs_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'attributes') is null then 'alarm'
-        when (arguments -> 'attributes' -> 'flow_logs_enabled') is null then 'alram'
-        when (arguments -> 'attributes' -> 'flow_logs_enabled')::bool then 'ok'
+        when (attributes_std -> 'attributes') is null then 'alarm'
+        when (attributes_std -> 'attributes' -> 'flow_logs_enabled') is null then 'alram'
+        when (attributes_std -> 'attributes' -> 'flow_logs_enabled')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'attributes') is null then ' flow log disabled'
-        when (arguments -> 'attributes' -> 'flow_logs_enabled') is null then ' flow log disabled'
-        when (arguments -> 'attributes' -> 'flow_logs_enabled')::bool then ' flow log enabled'
+      address || case
+        when (attributes_std -> 'attributes') is null then ' flow log disabled'
+        when (attributes_std -> 'attributes' -> 'flow_logs_enabled') is null then ' flow log disabled'
+        when (attributes_std -> 'attributes' -> 'flow_logs_enabled')::bool then ' flow log enabled'
         else ' flow log disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/globalaccelerator.sp
+++ b/query/globalaccelerator.sp
@@ -8,7 +8,7 @@ query "globalaccelerator_flow_logs_enabled" {
         when (attributes_std -> 'attributes' -> 'flow_logs_enabled')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'attributes') is null then ' flow log disabled'
         when (attributes_std -> 'attributes' -> 'flow_logs_enabled') is null then ' flow log disabled'
         when (attributes_std -> 'attributes' -> 'flow_logs_enabled')::bool then ' flow log enabled'

--- a/query/glue.sp
+++ b/query/glue.sp
@@ -97,7 +97,7 @@ query "glue_security_configuration_encryption_enabled" {
         and (attributes_std -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'job_bookmarks_encryption_mode') = 'CSE-KMS'
         and (attributes_std -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'kms_key_arn') is not null
         and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 's3_encryption_mode') <> 'DISABLED'
-        and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 'kms_key_arn') is not null  then 'ok'
+        and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 'kms_key_arn') is not null then 'ok'
         else 'alarm'
       end status,
       split_part(address, '.', 2) || case
@@ -106,7 +106,7 @@ query "glue_security_configuration_encryption_enabled" {
         and (attributes_std -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'job_bookmarks_encryption_mode') = 'CSE-KMS'
         and (attributes_std -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'kms_key_arn') is not null
         and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 's3_encryption_mode') <> 'DISABLED'
-        and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 'kms_key_arn') is not null  then ' encryption enabled'
+        and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 'kms_key_arn') is not null then ' encryption enabled'
         else ' encryption disabled'
       end || '.' reason
       ${local.common_dimensions_sql}

--- a/query/glue.sp
+++ b/query/glue.sp
@@ -1,13 +1,13 @@
 query "glue_crawler_security_configuration_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'security_configuration') is null then 'alarm'
+        when (attributes_std -> 'security_configuration') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'security_configuration') is null then ' security configuration disabled'
+      address || case
+        when (attributes_std -> 'security_configuration') is null then ' security configuration disabled'
         else ' security configuration enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "glue_crawler_security_configuration_enabled" {
 query "glue_dev_endpoint_security_configuration_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'security_configuration') is null then 'alarm'
+        when (attributes_std -> 'security_configuration') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'security_configuration') is null then ' security configuration disabled'
+      address || case
+        when (attributes_std -> 'security_configuration') is null then ' security configuration disabled'
         else ' security configuration enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -43,13 +43,13 @@ query "glue_dev_endpoint_security_configuration_enabled" {
 query "glue_job_security_configuration_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'security_configuration') is null then 'alarm'
+        when (attributes_std -> 'security_configuration') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'security_configuration') is null then ' security configuration disabled'
+      address || case
+        when (attributes_std -> 'security_configuration') is null then ' security configuration disabled'
         else ' security configuration enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -64,19 +64,19 @@ query "glue_job_security_configuration_enabled" {
 query "glue_data_catalog_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'data_catalog_encryption_settings' -> 'connection_password_encryption' ->> 'return_connection_password_encrypted') = 'true'
-        and (arguments -> 'data_catalog_encryption_settings' -> 'connection_password_encryption' ->> 'aws_kms_key_id') is not null
-        and (arguments -> 'data_catalog_encryption_settings' -> 'encryption_at_rest' ->> 'sse_aws_kms_key_id') is not null
-        and (arguments -> 'data_catalog_encryption_settings' -> 'encryption_at_rest' ->> 'catalog_encryption_mode') = 'SSE-KMS' then 'ok'
+        when (attributes_std -> 'data_catalog_encryption_settings' -> 'connection_password_encryption' ->> 'return_connection_password_encrypted') = 'true'
+        and (attributes_std -> 'data_catalog_encryption_settings' -> 'connection_password_encryption' ->> 'aws_kms_key_id') is not null
+        and (attributes_std -> 'data_catalog_encryption_settings' -> 'encryption_at_rest' ->> 'sse_aws_kms_key_id') is not null
+        and (attributes_std -> 'data_catalog_encryption_settings' -> 'encryption_at_rest' ->> 'catalog_encryption_mode') = 'SSE-KMS' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'data_catalog_encryption_settings' -> 'connection_password_encryption' ->> 'return_connection_password_encrypted') = 'true'
-        and (arguments -> 'data_catalog_encryption_settings' -> 'connection_password_encryption' ->> 'aws_kms_key_id') is not null
-        and (arguments -> 'data_catalog_encryption_settings' -> 'encryption_at_rest' ->> 'sse_aws_kms_key_id') is not null
-        and (arguments -> 'data_catalog_encryption_settings' -> 'encryption_at_rest' ->> 'catalog_encryption_mode') = 'SSE-KMS' then ' encryption enabled'
+      address || case
+        when (attributes_std -> 'data_catalog_encryption_settings' -> 'connection_password_encryption' ->> 'return_connection_password_encrypted') = 'true'
+        and (attributes_std -> 'data_catalog_encryption_settings' -> 'connection_password_encryption' ->> 'aws_kms_key_id') is not null
+        and (attributes_std -> 'data_catalog_encryption_settings' -> 'encryption_at_rest' ->> 'sse_aws_kms_key_id') is not null
+        and (attributes_std -> 'data_catalog_encryption_settings' -> 'encryption_at_rest' ->> 'catalog_encryption_mode') = 'SSE-KMS' then ' encryption enabled'
         else ' encryption disabled'
       end || '.' reason
       ${local.common_dimensions_sql}
@@ -90,23 +90,23 @@ query "glue_data_catalog_encryption_enabled" {
 query "glue_security_configuration_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encryption_configuration' -> 'cloudwatch_encryption' ->> 'cloudwatch_encryption_mode') = 'SSE-KMS'
-        and (arguments -> 'encryption_configuration' -> 'cloudwatch_encryption' ->> 'kms_key_arn') is not null
-        and (arguments -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'job_bookmarks_encryption_mode') = 'CSE-KMS'
-        and (arguments -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'kms_key_arn') is not null
-        and (arguments -> 'encryption_configuration' -> 's3_encryption' ->> 's3_encryption_mode') <> 'DISABLED'
-        and (arguments -> 'encryption_configuration' -> 's3_encryption' ->> 'kms_key_arn') is not null  then 'ok'
+        when (attributes_std -> 'encryption_configuration' -> 'cloudwatch_encryption' ->> 'cloudwatch_encryption_mode') = 'SSE-KMS'
+        and (attributes_std -> 'encryption_configuration' -> 'cloudwatch_encryption' ->> 'kms_key_arn') is not null
+        and (attributes_std -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'job_bookmarks_encryption_mode') = 'CSE-KMS'
+        and (attributes_std -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'kms_key_arn') is not null
+        and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 's3_encryption_mode') <> 'DISABLED'
+        and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 'kms_key_arn') is not null  then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'encryption_configuration' -> 'cloudwatch_encryption' ->> 'cloudwatch_encryption_mode') = 'SSE-KMS'
-        and (arguments -> 'encryption_configuration' -> 'cloudwatch_encryption' ->> 'kms_key_arn') is not null
-        and (arguments -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'job_bookmarks_encryption_mode') = 'CSE-KMS'
-        and (arguments -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'kms_key_arn') is not null
-        and (arguments -> 'encryption_configuration' -> 's3_encryption' ->> 's3_encryption_mode') <> 'DISABLED'
-        and (arguments -> 'encryption_configuration' -> 's3_encryption' ->> 'kms_key_arn') is not null  then ' encryption enabled'
+      address || case
+        when (attributes_std -> 'encryption_configuration' -> 'cloudwatch_encryption' ->> 'cloudwatch_encryption_mode') = 'SSE-KMS'
+        and (attributes_std -> 'encryption_configuration' -> 'cloudwatch_encryption' ->> 'kms_key_arn') is not null
+        and (attributes_std -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'job_bookmarks_encryption_mode') = 'CSE-KMS'
+        and (attributes_std -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'kms_key_arn') is not null
+        and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 's3_encryption_mode') <> 'DISABLED'
+        and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 'kms_key_arn') is not null  then ' encryption enabled'
         else ' encryption disabled'
       end || '.' reason
       ${local.common_dimensions_sql}

--- a/query/glue.sp
+++ b/query/glue.sp
@@ -6,7 +6,7 @@ query "glue_crawler_security_configuration_enabled" {
         when (attributes_std -> 'security_configuration') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'security_configuration') is null then ' security configuration disabled'
         else ' security configuration enabled'
       end || '.' reason
@@ -27,7 +27,7 @@ query "glue_dev_endpoint_security_configuration_enabled" {
         when (attributes_std -> 'security_configuration') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'security_configuration') is null then ' security configuration disabled'
         else ' security configuration enabled'
       end || '.' reason
@@ -48,7 +48,7 @@ query "glue_job_security_configuration_enabled" {
         when (attributes_std -> 'security_configuration') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'security_configuration') is null then ' security configuration disabled'
         else ' security configuration enabled'
       end || '.' reason
@@ -72,7 +72,7 @@ query "glue_data_catalog_encryption_enabled" {
         and (attributes_std -> 'data_catalog_encryption_settings' -> 'encryption_at_rest' ->> 'catalog_encryption_mode') = 'SSE-KMS' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'data_catalog_encryption_settings' -> 'connection_password_encryption' ->> 'return_connection_password_encrypted') = 'true'
         and (attributes_std -> 'data_catalog_encryption_settings' -> 'connection_password_encryption' ->> 'aws_kms_key_id') is not null
         and (attributes_std -> 'data_catalog_encryption_settings' -> 'encryption_at_rest' ->> 'sse_aws_kms_key_id') is not null
@@ -100,7 +100,7 @@ query "glue_security_configuration_encryption_enabled" {
         and (attributes_std -> 'encryption_configuration' -> 's3_encryption' ->> 'kms_key_arn') is not null  then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encryption_configuration' -> 'cloudwatch_encryption' ->> 'cloudwatch_encryption_mode') = 'SSE-KMS'
         and (attributes_std -> 'encryption_configuration' -> 'cloudwatch_encryption' ->> 'kms_key_arn') is not null
         and (attributes_std -> 'encryption_configuration' -> 'job_bookmarks_encryption' ->> 'job_bookmarks_encryption_mode') = 'CSE-KMS'

--- a/query/guardduty.sp
+++ b/query/guardduty.sp
@@ -7,7 +7,7 @@ query "guardduty_enabled" {
         when (attributes_std -> 'enable')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'enable') is null then ' guardduty enabled'
         when (attributes_std -> 'enable')::bool then ' guardduty enabled'
         else ' guardduty disabled'

--- a/query/guardduty.sp
+++ b/query/guardduty.sp
@@ -1,15 +1,15 @@
 query "guardduty_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'enable') is null then 'ok'
-        when (arguments -> 'enable')::bool then 'ok'
+        when (attributes_std -> 'enable') is null then 'ok'
+        when (attributes_std -> 'enable')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'enable') is null then ' guardduty enabled'
-        when (arguments -> 'enable')::bool then ' guardduty enabled'
+      address || case
+        when (attributes_std -> 'enable') is null then ' guardduty enabled'
+        when (attributes_std -> 'enable')::bool then ' guardduty enabled'
         else ' guardduty disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/iam.sp
+++ b/query/iam.sp
@@ -7,7 +7,7 @@ query "iam_account_password_policy_min_length_14" {
         when (attributes_std -> 'minimum_password_length')::integer >= 14 then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'minimum_password_length') is null then ' ''minimum_password_length'' is not defined'
         when (attributes_std -> 'minimum_password_length')::integer >= 14 then ' ''minimum_password_length'' is set and greater than 14'
         else ' ''minimum_password_length'' is set and less than 14'
@@ -29,7 +29,7 @@ query "iam_account_password_policy_one_lowercase_letter" {
         when (attributes_std -> 'require_lowercase_characters')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'require_lowercase_characters') is null then ' lowercase character not set to required'
         when (attributes_std -> 'require_lowercase_characters')::boolean then ' lowercase character set to required'
         else ' lowercase character not set to required'
@@ -51,7 +51,7 @@ query "iam_account_password_policy_one_number" {
         when (attributes_std -> 'require_numbers')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'require_numbers') is null then ' number not set to required'
         when (attributes_std -> 'require_numbers')::bool then ' number set to required'
         else ' number not set to required'
@@ -73,7 +73,7 @@ query "iam_account_password_policy_one_symbol" {
         when (attributes_std -> 'require_symbols')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'require_symbols') is null then ' symbol not set to required'
         when (attributes_std -> 'require_symbols')::boolean then ' symbol set to required'
         else ' symbol not set to required'
@@ -95,7 +95,7 @@ query "iam_account_password_policy_one_uppercase_letter" {
         when (attributes_std -> 'require_uppercase_characters')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'require_uppercase_characters') is null then ' ''require_uppercase_characters'' not defined'
         when (attributes_std -> 'require_uppercase_characters')::boolean then ' uppercase characters set to required'
         else ' uppercase characters not set to required'
@@ -117,7 +117,7 @@ query "iam_account_password_policy_reuse_24" {
         when (attributes_std -> 'password_reuse_prevention')::integer >= 24 then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'password_reuse_prevention') is null then ' password reuse prevention not set'
         when (attributes_std -> 'password_reuse_prevention')::integer >= 24 then ' password reuse prevention set to ' || (attributes_std ->> 'password_reuse_prevention') || ' days'
         else ' password reuse prevention set to ' || (attributes_std ->> 'password_reuse_prevention') || ' days'
@@ -144,7 +144,7 @@ query "iam_account_password_policy_strong_min_length_8" {
         then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when
           (attributes_std -> 'minimum_password_length')::integer >= 8
           and (attributes_std -> 'require_lowercase_characters')::bool
@@ -177,7 +177,7 @@ query "iam_account_password_policy_strong" {
         then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when
           (attributes_std -> 'minimum_password_length')::integer >= 14
           and (attributes_std -> 'require_lowercase_characters')::bool
@@ -205,7 +205,7 @@ query "iam_password_policy_expire_90" {
         when (attributes_std -> 'max_password_age')::integer <= 90 then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'max_password_age') is null then ' password expiration not set'
         when (attributes_std -> 'max_password_age')::integer <= 90 then ' password expiration set to ' || (attributes_std ->> 'max_password_age') || ' days'
         else ' password expiration set to ' || (attributes_std ->> 'max_password_age') || ' days'

--- a/query/iam.sp
+++ b/query/iam.sp
@@ -1,15 +1,15 @@
 query "iam_account_password_policy_min_length_14" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'minimum_password_length') is null then 'alarm'
-        when (arguments -> 'minimum_password_length')::integer >= 14 then 'ok'
+        when (attributes_std -> 'minimum_password_length') is null then 'alarm'
+        when (attributes_std -> 'minimum_password_length')::integer >= 14 then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'minimum_password_length') is null then ' ''minimum_password_length'' is not defined'
-        when (arguments -> 'minimum_password_length')::integer >= 14 then ' ''minimum_password_length'' is set and greater than 14'
+      address || case
+        when (attributes_std -> 'minimum_password_length') is null then ' ''minimum_password_length'' is not defined'
+        when (attributes_std -> 'minimum_password_length')::integer >= 14 then ' ''minimum_password_length'' is set and greater than 14'
         else ' ''minimum_password_length'' is set and less than 14'
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -23,15 +23,15 @@ query "iam_account_password_policy_min_length_14" {
 query "iam_account_password_policy_one_lowercase_letter" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'require_lowercase_characters') is null then 'alarm'
-        when (arguments -> 'require_lowercase_characters')::boolean then 'ok'
+        when (attributes_std -> 'require_lowercase_characters') is null then 'alarm'
+        when (attributes_std -> 'require_lowercase_characters')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'require_lowercase_characters') is null then ' lowercase character not set to required'
-        when (arguments -> 'require_lowercase_characters')::boolean then ' lowercase character set to required'
+      address || case
+        when (attributes_std -> 'require_lowercase_characters') is null then ' lowercase character not set to required'
+        when (attributes_std -> 'require_lowercase_characters')::boolean then ' lowercase character set to required'
         else ' lowercase character not set to required'
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -45,15 +45,15 @@ query "iam_account_password_policy_one_lowercase_letter" {
 query "iam_account_password_policy_one_number" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'require_numbers') is null then 'alarm'
-        when (arguments -> 'require_numbers')::bool then 'ok'
+        when (attributes_std -> 'require_numbers') is null then 'alarm'
+        when (attributes_std -> 'require_numbers')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'require_numbers') is null then ' number not set to required'
-        when (arguments -> 'require_numbers')::bool then ' number set to required'
+      address || case
+        when (attributes_std -> 'require_numbers') is null then ' number not set to required'
+        when (attributes_std -> 'require_numbers')::bool then ' number set to required'
         else ' number not set to required'
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -67,15 +67,15 @@ query "iam_account_password_policy_one_number" {
 query "iam_account_password_policy_one_symbol" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'require_symbols') is null then 'alarm'
-        when (arguments -> 'require_symbols')::boolean then 'ok'
+        when (attributes_std -> 'require_symbols') is null then 'alarm'
+        when (attributes_std -> 'require_symbols')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'require_symbols') is null then ' symbol not set to required'
-        when (arguments -> 'require_symbols')::boolean then ' symbol set to required'
+      address || case
+        when (attributes_std -> 'require_symbols') is null then ' symbol not set to required'
+        when (attributes_std -> 'require_symbols')::boolean then ' symbol set to required'
         else ' symbol not set to required'
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -89,15 +89,15 @@ query "iam_account_password_policy_one_symbol" {
 query "iam_account_password_policy_one_uppercase_letter" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'require_uppercase_characters') is null then 'alarm'
-        when (arguments -> 'require_uppercase_characters')::boolean then 'ok'
+        when (attributes_std -> 'require_uppercase_characters') is null then 'alarm'
+        when (attributes_std -> 'require_uppercase_characters')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'require_uppercase_characters') is null then ' ''require_uppercase_characters'' not defined'
-        when (arguments -> 'require_uppercase_characters')::boolean then ' uppercase characters set to required'
+      address || case
+        when (attributes_std -> 'require_uppercase_characters') is null then ' ''require_uppercase_characters'' not defined'
+        when (attributes_std -> 'require_uppercase_characters')::boolean then ' uppercase characters set to required'
         else ' uppercase characters not set to required'
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -111,16 +111,16 @@ query "iam_account_password_policy_one_uppercase_letter" {
 query "iam_account_password_policy_reuse_24" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'password_reuse_prevention') is null then 'alarm'
-        when (arguments -> 'password_reuse_prevention')::integer >= 24 then 'ok'
+        when (attributes_std -> 'password_reuse_prevention') is null then 'alarm'
+        when (attributes_std -> 'password_reuse_prevention')::integer >= 24 then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'password_reuse_prevention') is null then ' password reuse prevention not set'
-        when (arguments -> 'password_reuse_prevention')::integer >= 24 then ' password reuse prevention set to ' || (arguments ->> 'password_reuse_prevention') || ' days'
-        else ' password reuse prevention set to ' || (arguments ->> 'password_reuse_prevention') || ' days'
+      address || case
+        when (attributes_std -> 'password_reuse_prevention') is null then ' password reuse prevention not set'
+        when (attributes_std -> 'password_reuse_prevention')::integer >= 24 then ' password reuse prevention set to ' || (attributes_std ->> 'password_reuse_prevention') || ' days'
+        else ' password reuse prevention set to ' || (attributes_std ->> 'password_reuse_prevention') || ' days'
       end || '.' as reason
       ${local.common_dimensions_sql}
     from
@@ -133,24 +133,24 @@ query "iam_account_password_policy_reuse_24" {
 query "iam_account_password_policy_strong_min_length_8" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-          (arguments -> 'minimum_password_length')::integer >= 8
-          and (arguments -> 'require_lowercase_characters')::bool
-          and (arguments -> 'require_uppercase_characters')::bool
-          and (arguments -> 'require_numbers')::bool
-          and (arguments -> 'require_symbols')::bool
+          (attributes_std -> 'minimum_password_length')::integer >= 8
+          and (attributes_std -> 'require_lowercase_characters')::bool
+          and (attributes_std -> 'require_uppercase_characters')::bool
+          and (attributes_std -> 'require_numbers')::bool
+          and (attributes_std -> 'require_symbols')::bool
         then 'ok'
         else 'alarm'
       end as status,
-      name || case
+      address || case
         when
-          (arguments -> 'minimum_password_length')::integer >= 8
-          and (arguments -> 'require_lowercase_characters')::bool
-          and (arguments -> 'require_uppercase_characters')::bool
-          and (arguments -> 'require_numbers')::bool
-          and (arguments -> 'require_symbols')::bool
+          (attributes_std -> 'minimum_password_length')::integer >= 8
+          and (attributes_std -> 'require_lowercase_characters')::bool
+          and (attributes_std -> 'require_uppercase_characters')::bool
+          and (attributes_std -> 'require_numbers')::bool
+          and (attributes_std -> 'require_symbols')::bool
         then ' Strong password policies configured'
         else ' Strong password policies not configured'
       end || '.' as reason
@@ -165,26 +165,26 @@ query "iam_account_password_policy_strong_min_length_8" {
 query "iam_account_password_policy_strong" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-          (arguments -> 'minimum_password_length')::integer >= 14
-          and (arguments -> 'require_lowercase_characters')::bool
-          and (arguments -> 'require_uppercase_characters')::bool
-          and (arguments -> 'require_numbers')::bool
-          and (arguments -> 'require_symbols')::bool
-          and (arguments -> 'password_reuse_prevention')::integer >= 24
+          (attributes_std -> 'minimum_password_length')::integer >= 14
+          and (attributes_std -> 'require_lowercase_characters')::bool
+          and (attributes_std -> 'require_uppercase_characters')::bool
+          and (attributes_std -> 'require_numbers')::bool
+          and (attributes_std -> 'require_symbols')::bool
+          and (attributes_std -> 'password_reuse_prevention')::integer >= 24
         then 'ok'
         else 'alarm'
       end as status,
-      name || case
+      address || case
         when
-          (arguments -> 'minimum_password_length')::integer >= 14
-          and (arguments -> 'require_lowercase_characters')::bool
-          and (arguments -> 'require_uppercase_characters')::bool
-          and (arguments -> 'require_numbers')::bool
-          and (arguments -> 'require_symbols')::bool
-          and (arguments -> 'password_reuse_prevention')::integer >= 24
+          (attributes_std -> 'minimum_password_length')::integer >= 14
+          and (attributes_std -> 'require_lowercase_characters')::bool
+          and (attributes_std -> 'require_uppercase_characters')::bool
+          and (attributes_std -> 'require_numbers')::bool
+          and (attributes_std -> 'require_symbols')::bool
+          and (attributes_std -> 'password_reuse_prevention')::integer >= 24
         then ' Strong password policies configured'
         else ' Strong password policies not configured'
       end || '.' as reason
@@ -199,16 +199,16 @@ query "iam_account_password_policy_strong" {
 query "iam_password_policy_expire_90" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'max_password_age') is null then 'alarm'
-        when (arguments -> 'max_password_age')::integer <= 90 then 'ok'
+        when (attributes_std -> 'max_password_age') is null then 'alarm'
+        when (attributes_std -> 'max_password_age')::integer <= 90 then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'max_password_age') is null then ' password expiration not set'
-        when (arguments -> 'max_password_age')::integer <= 90 then ' password expiration set to ' || (arguments ->> 'max_password_age') || ' days'
-        else ' password expiration set to ' || (arguments ->> 'max_password_age') || ' days'
+      address || case
+        when (attributes_std -> 'max_password_age') is null then ' password expiration not set'
+        when (attributes_std -> 'max_password_age')::integer <= 90 then ' password expiration set to ' || (attributes_std ->> 'max_password_age') || ' days'
+        else ' password expiration set to ' || (attributes_std ->> 'max_password_age') || ' days'
       end || '.' as reason
       ${local.common_dimensions_sql}
     from

--- a/query/kendra.sp
+++ b/query/kendra.sp
@@ -1,13 +1,13 @@
 query "kendra_index_server_side_encryption_uses_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'server_side_encryption_configuration' ->> 'kms_key_id') is not null then 'ok'
+        when (attributes_std -> 'server_side_encryption_configuration' ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'server_side_encryption_configuration' ->> 'kms_key_id') is not null then ' uses KMS CMK'
+      address || case
+        when (attributes_std -> 'server_side_encryption_configuration' ->> 'kms_key_id') is not null then ' uses KMS CMK'
         else ' does not use KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/kendra.sp
+++ b/query/kendra.sp
@@ -6,7 +6,7 @@ query "kendra_index_server_side_encryption_uses_kms_cmk" {
         when (attributes_std -> 'server_side_encryption_configuration' ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'server_side_encryption_configuration' ->> 'kms_key_id') is not null then ' uses KMS CMK'
         else ' does not use KMS CMK'
       end || '.' reason

--- a/query/keyspace.sp
+++ b/query/keyspace.sp
@@ -6,7 +6,7 @@ query "keyspaces_table_encrypted_with_kms_cmk" {
         when (attributes_std -> 'encryption_specification' -> 'kms_key_identifier') is not null and (attributes_std -> 'encryption_specification' ->> 'type') = 'CUSTOMER_MANAGED_KMS_KEY' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encryption_specification' -> 'kms_key_id') is not null and (attributes_std -> 'encryption_specification' ->> 'type') = 'CUSTOMER_MANAGED_KMS_KEY' then ' uses KMS CMK'
         else ' does not use KMS CMK'
       end || '.' reason

--- a/query/keyspace.sp
+++ b/query/keyspace.sp
@@ -1,13 +1,13 @@
 query "keyspaces_table_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encryption_specification' -> 'kms_key_identifier') is not null and (arguments -> 'encryption_specification' ->> 'type') = 'CUSTOMER_MANAGED_KMS_KEY' then 'ok'
+        when (attributes_std -> 'encryption_specification' -> 'kms_key_identifier') is not null and (attributes_std -> 'encryption_specification' ->> 'type') = 'CUSTOMER_MANAGED_KMS_KEY' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'encryption_specification' -> 'kms_key_id') is not null and (arguments -> 'encryption_specification' ->> 'type') = 'CUSTOMER_MANAGED_KMS_KEY' then ' uses KMS CMK'
+      address || case
+        when (attributes_std -> 'encryption_specification' -> 'kms_key_id') is not null and (attributes_std -> 'encryption_specification' ->> 'type') = 'CUSTOMER_MANAGED_KMS_KEY' then ' uses KMS CMK'
         else ' does not use KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/kinesis.sp
+++ b/query/kinesis.sp
@@ -6,7 +6,7 @@ query "kinesis_stream_encryption_at_rest_enabled" {
         when (attributes_std ->> 'encryption_type') = 'KMS' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'encryption_type') = 'KMS' then ' encrypted aty rest'
         else ' not encrypted at rest'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "kinesis_firehose_delivery_stream_server_side_encryption_enabled" {
         when (attributes_std -> 'server_side_encryption' ->> 'enabled') = 'true' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'server_side_encryption' ->> 'enabled') = 'true' then ' server side encryption enabled'
         else ' server side encryption disabled'
       end || '.' as reason
@@ -48,7 +48,7 @@ query "kinesis_firehose_delivery_stream_encrypted_with_kms_cmk" {
         when (attributes_std -> 'server_side_encryption' ->> 'key_type') = 'CUSTOMER_MANAGED_CMK' and (attributes_std -> 'server_side_encryption' ->> 'key_arn') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'server_side_encryption' ->> 'key_type') = 'CUSTOMER_MANAGED_CMK' and (attributes_std -> 'server_side_encryption' ->> 'key_arn') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' as reason
@@ -69,7 +69,7 @@ query "kinesis_stream_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' as reason
@@ -90,7 +90,7 @@ query "kinesis_video_stream_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' as reason

--- a/query/kinesis.sp
+++ b/query/kinesis.sp
@@ -1,13 +1,13 @@
 query "kinesis_stream_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'encryption_type') = 'KMS' then 'ok'
+        when (attributes_std ->> 'encryption_type') = 'KMS' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'encryption_type') = 'KMS' then ' encrypted aty rest'
+      address || case
+        when (attributes_std ->> 'encryption_type') = 'KMS' then ' encrypted aty rest'
         else ' not encrypted at rest'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "kinesis_stream_encryption_at_rest_enabled" {
 query "kinesis_firehose_delivery_stream_server_side_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'server_side_encryption' ->> 'enabled') = 'true' then 'ok'
+        when (attributes_std -> 'server_side_encryption' ->> 'enabled') = 'true' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'server_side_encryption' ->> 'enabled') = 'true' then ' server side encryption enabled'
+      address || case
+        when (attributes_std -> 'server_side_encryption' ->> 'enabled') = 'true' then ' server side encryption enabled'
         else ' server side encryption disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -43,13 +43,13 @@ query "kinesis_firehose_delivery_stream_server_side_encryption_enabled" {
 query "kinesis_firehose_delivery_stream_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'server_side_encryption' ->> 'key_type') = 'CUSTOMER_MANAGED_CMK' and (arguments -> 'server_side_encryption' ->> 'key_arn') is not null then 'ok'
+        when (attributes_std -> 'server_side_encryption' ->> 'key_type') = 'CUSTOMER_MANAGED_CMK' and (attributes_std -> 'server_side_encryption' ->> 'key_arn') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'server_side_encryption' ->> 'key_type') = 'CUSTOMER_MANAGED_CMK' and (arguments -> 'server_side_encryption' ->> 'key_arn') is not null then ' encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'server_side_encryption' ->> 'key_type') = 'CUSTOMER_MANAGED_CMK' and (attributes_std -> 'server_side_encryption' ->> 'key_arn') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -64,13 +64,13 @@ query "kinesis_firehose_delivery_stream_encrypted_with_kms_cmk" {
 query "kinesis_stream_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is not null then 'ok'
+        when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -85,13 +85,13 @@ query "kinesis_stream_encrypted_with_kms_cmk" {
 query "kinesis_video_stream_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is not null then 'ok'
+        when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/kms.sp
+++ b/query/kms.sp
@@ -7,7 +7,7 @@ query "kms_cmk_rotation_enabled" {
         when (attributes_std -> 'enable_key_rotation')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'enable_key_rotation') is null then ' key rotation disabled'
         when (attributes_std -> 'enable_key_rotation')::boolean then ' key rotation enabled'
         else ' key rotation disabled'

--- a/query/kms.sp
+++ b/query/kms.sp
@@ -1,15 +1,15 @@
 query "kms_cmk_rotation_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'enable_key_rotation') is null then 'alarm'
-        when (arguments -> 'enable_key_rotation')::boolean then 'ok'
+        when (attributes_std -> 'enable_key_rotation') is null then 'alarm'
+        when (attributes_std -> 'enable_key_rotation')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'enable_key_rotation') is null then ' key rotation disabled'
-        when (arguments -> 'enable_key_rotation')::boolean then ' key rotation enabled'
+      address || case
+        when (attributes_std -> 'enable_key_rotation') is null then ' key rotation disabled'
+        when (attributes_std -> 'enable_key_rotation')::boolean then ' key rotation enabled'
         else ' key rotation disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/lambda.sp
+++ b/query/lambda.sp
@@ -1,15 +1,15 @@
 query "lambda_function_concurrent_execution_limit_configured" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'reserved_concurrent_executions') is null then 'alarm'
-        when (arguments -> 'reserved_concurrent_executions')::integer = -1 then 'alarm'
+        when (attributes_std -> 'reserved_concurrent_executions') is null then 'alarm'
+        when (attributes_std -> 'reserved_concurrent_executions')::integer = -1 then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'reserved_concurrent_executions') is null then ' function-level concurrent execution limit not configured'
-        when (arguments -> 'reserved_concurrent_executions')::integer = -1 then ' function-level concurrent execution limit not configured'
+      address || case
+        when (attributes_std -> 'reserved_concurrent_executions') is null then ' function-level concurrent execution limit not configured'
+        when (attributes_std -> 'reserved_concurrent_executions')::integer = -1 then ' function-level concurrent execution limit not configured'
         else ' function-level concurrent execution limit configured'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -24,13 +24,13 @@ query "lambda_function_concurrent_execution_limit_configured" {
 query "lambda_function_dead_letter_queue_configured" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'dead_letter_config') is null then 'alarm'
+        when (attributes_std -> 'dead_letter_config') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'dead_letter_config') is null then ' not configured with dead-letter queue'
+      address || case
+        when (attributes_std -> 'dead_letter_config') is null then ' not configured with dead-letter queue'
         else ' configured with dead-letter queue'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -45,13 +45,13 @@ query "lambda_function_dead_letter_queue_configured" {
 query "lambda_function_in_vpc" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'vpc_config') is null then 'alarm'
+        when (attributes_std -> 'vpc_config') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'vpc_config') is null then ' is not in VPC'
+      address || case
+        when (attributes_std -> 'vpc_config') is null then ' is not in VPC'
         else ' is in VPC'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -66,16 +66,16 @@ query "lambda_function_in_vpc" {
 query "lambda_function_use_latest_runtime" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'runtime') is null then 'skip'
-        when (arguments ->> 'runtime') in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then 'ok'
+        when (attributes_std ->> 'runtime') is null then 'skip'
+        when (attributes_std ->> 'runtime') in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'runtime') is null then ' runtime not set'
-        when (arguments ->> 'runtime') in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then ' uses latest runtime - ' || (arguments ->> 'runtime') || '.'
-        else ' uses ' || (arguments ->> 'runtime')|| ' which is not the latest version.'
+      address || case
+        when (attributes_std ->> 'runtime') is null then ' runtime not set'
+        when (attributes_std ->> 'runtime') in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then ' uses latest runtime - ' || (attributes_std ->> 'runtime') || '.'
+        else ' uses ' || (attributes_std ->> 'runtime')|| ' which is not the latest version.'
       end as reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}
@@ -89,15 +89,15 @@ query "lambda_function_use_latest_runtime" {
 query "lambda_function_xray_tracing_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'tracing_config') is null then 'alarm'
-        when (arguments -> 'tracing_config' ->> 'mode') = 'Active' then 'ok'
+        when (attributes_std -> 'tracing_config') is null then 'alarm'
+        when (attributes_std -> 'tracing_config' ->> 'mode') = 'Active' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'tracing_config') is null then ' has X-Ray tracing disabled'
-        when (arguments -> 'tracing_config' ->> 'mode') = 'Active' then ' has X-Ray tracing enabled'
+      address || case
+        when (attributes_std -> 'tracing_config') is null then ' has X-Ray tracing disabled'
+        when (attributes_std -> 'tracing_config' ->> 'mode') = 'Active' then ' has X-Ray tracing enabled'
         else ' has X-Ray tracing disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -112,13 +112,13 @@ query "lambda_function_xray_tracing_enabled" {
 query "lambda_function_url_auth_type_configured" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'authorization_type') = 'NONE' then 'alarm'
+        when (attributes_std ->> 'authorization_type') = 'NONE' then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments ->> 'authorization_type') = 'NONE' then ' URLs AuthType is not configured'
+      address || case
+        when (attributes_std ->> 'authorization_type') = 'NONE' then ' URLs AuthType is not configured'
         else ' URLs AuthType is configured'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -133,13 +133,13 @@ query "lambda_function_url_auth_type_configured" {
 query "lambda_function_code_signing_configured" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'code_signing_config_arn') is null then 'alarm'
+        when (attributes_std -> 'code_signing_config_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'code_signing_config_arn') is null then ' code signing not configured'
+      address || case
+        when (attributes_std -> 'code_signing_config_arn') is null then ' code signing not configured'
         else ' code signing is configured'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -155,10 +155,10 @@ query "lambda_function_variables_no_sensitive_data" {
   sql = <<-EOQ
     with function_vaiable_with_sensitive_data as (
       select
-        distinct (type || ' ' || name ) as name
+        distinct (address ) as name
       from
         terraform_resource
-        join jsonb_each_text(arguments -> 'environment' -> 'variables') d on true
+        join jsonb_each_text(attributes_std -> 'environment' -> 'variables') d on true
       where
         type = 'aws_lambda_function'
         and (
@@ -174,7 +174,7 @@ query "lambda_function_variables_no_sensitive_data" {
         when s.name is not null then 'alarm'
         else 'ok'
       end as status,
-      r.name || case
+      r.address || case
         when s.name is not null then ' has potential sensitive data'
         else ' has no sensitive data'
       end || '.' as reason
@@ -191,17 +191,17 @@ query "lambda_function_variables_no_sensitive_data" {
 query "lambda_function_environment_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'environment') is not null and (arguments -> 'kms_key_arn') is not null then 'ok'
-        when (arguments -> 'environment') is not null and (arguments -> 'kms_key_arn') is null then 'alarm'
-        when (arguments -> 'environment') is null and (arguments -> 'kms_key_arn') is null then 'skip'
+        when (attributes_std -> 'environment') is not null and (attributes_std -> 'kms_key_arn') is not null then 'ok'
+        when (attributes_std -> 'environment') is not null and (attributes_std -> 'kms_key_arn') is null then 'alarm'
+        when (attributes_std -> 'environment') is null and (attributes_std -> 'kms_key_arn') is null then 'skip'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'environment') is not null and (arguments -> 'kms_key_arn') is not null then ' environment encryption enabled'
-        when (arguments -> 'environment') is not null and (arguments -> 'kms_key_arn') is null then ' environment encryption disabled'
-        when (arguments -> 'environment') is null and (arguments -> 'kms_key_arn') is null then ' no environment exists'
+      address || case
+        when (attributes_std -> 'environment') is not null and (attributes_std -> 'kms_key_arn') is not null then ' environment encryption enabled'
+        when (attributes_std -> 'environment') is not null and (attributes_std -> 'kms_key_arn') is null then ' environment encryption disabled'
+        when (attributes_std -> 'environment') is null and (attributes_std -> 'kms_key_arn') is null then ' no environment exists'
         else ' encryption is enabled even though no environment exists'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/lambda.sp
+++ b/query/lambda.sp
@@ -7,7 +7,7 @@ query "lambda_function_concurrent_execution_limit_configured" {
         when (attributes_std -> 'reserved_concurrent_executions')::integer = -1 then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'reserved_concurrent_executions') is null then ' function-level concurrent execution limit not configured'
         when (attributes_std -> 'reserved_concurrent_executions')::integer = -1 then ' function-level concurrent execution limit not configured'
         else ' function-level concurrent execution limit configured'
@@ -29,7 +29,7 @@ query "lambda_function_dead_letter_queue_configured" {
         when (attributes_std -> 'dead_letter_config') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'dead_letter_config') is null then ' not configured with dead-letter queue'
         else ' configured with dead-letter queue'
       end || '.' as reason
@@ -50,7 +50,7 @@ query "lambda_function_in_vpc" {
         when (attributes_std -> 'vpc_config') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'vpc_config') is null then ' is not in VPC'
         else ' is in VPC'
       end || '.' as reason
@@ -72,7 +72,7 @@ query "lambda_function_use_latest_runtime" {
         when (attributes_std ->> 'runtime') in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'runtime') is null then ' runtime not set'
         when (attributes_std ->> 'runtime') in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then ' uses latest runtime - ' || (attributes_std ->> 'runtime') || '.'
         else ' uses ' || (attributes_std ->> 'runtime')|| ' which is not the latest version.'
@@ -95,7 +95,7 @@ query "lambda_function_xray_tracing_enabled" {
         when (attributes_std -> 'tracing_config' ->> 'mode') = 'Active' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'tracing_config') is null then ' has X-Ray tracing disabled'
         when (attributes_std -> 'tracing_config' ->> 'mode') = 'Active' then ' has X-Ray tracing enabled'
         else ' has X-Ray tracing disabled'
@@ -117,7 +117,7 @@ query "lambda_function_url_auth_type_configured" {
         when (attributes_std ->> 'authorization_type') = 'NONE' then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'authorization_type') = 'NONE' then ' URLs AuthType is not configured'
         else ' URLs AuthType is configured'
       end || '.' as reason
@@ -138,7 +138,7 @@ query "lambda_function_code_signing_configured" {
         when (attributes_std -> 'code_signing_config_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'code_signing_config_arn') is null then ' code signing not configured'
         else ' code signing is configured'
       end || '.' as reason
@@ -169,12 +169,12 @@ query "lambda_function_variables_no_sensitive_data" {
       )
     )
     select
-      r.type || ' ' || r.name as resource,
+      r.address as resource,
       case
         when s.name is not null then 'alarm'
         else 'ok'
       end as status,
-      r.address || case
+      split_part(r.address, '.', 2) || case
         when s.name is not null then ' has potential sensitive data'
         else ' has no sensitive data'
       end || '.' as reason
@@ -182,7 +182,7 @@ query "lambda_function_variables_no_sensitive_data" {
       ${local.common_dimensions_sql}
     from
       terraform_resource as r
-      left join function_vaiable_with_sensitive_data as s on s.name = concat(r.type || ' ' || r.name)
+      left join function_vaiable_with_sensitive_data as s on s.name = r.address
     where
       r.type = 'aws_lambda_function';
   EOQ
@@ -198,7 +198,7 @@ query "lambda_function_environment_encryption_enabled" {
         when (attributes_std -> 'environment') is null and (attributes_std -> 'kms_key_arn') is null then 'skip'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'environment') is not null and (attributes_std -> 'kms_key_arn') is not null then ' environment encryption enabled'
         when (attributes_std -> 'environment') is not null and (attributes_std -> 'kms_key_arn') is null then ' environment encryption disabled'
         when (attributes_std -> 'environment') is null and (attributes_std -> 'kms_key_arn') is null then ' no environment exists'

--- a/query/mqbroker.sp
+++ b/query/mqbroker.sp
@@ -1,13 +1,13 @@
 query "mq_broker_audit_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments ->> 'engine_type') = 'RabbitMQ') and (arguments -> 'logs' ->> 'audit')::bool then 'ok'
+        when ((attributes_std ->> 'engine_type') = 'RabbitMQ') and (attributes_std -> 'logs' ->> 'audit')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when ((arguments ->> 'engine_type') = 'RabbitMQ') and (arguments -> 'logs' ->> 'audit')::bool is null then ' audit logging enabled'
+      address || case
+        when ((attributes_std ->> 'engine_type') = 'RabbitMQ') and (attributes_std -> 'logs' ->> 'audit')::bool is null then ' audit logging enabled'
         else ' audit logging disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "mq_broker_audit_logging_enabled" {
 query "mq_broker_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments -> 'encryption_option' ->> 'use_aws_owned_key')::bool and (arguments -> 'encryption_option' ->> 'kms_key_id') is null) then 'alarm'
+        when ((attributes_std -> 'encryption_option' ->> 'use_aws_owned_key')::bool and (attributes_std -> 'encryption_option' ->> 'kms_key_id') is null) then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when ((arguments -> 'encryption_option' ->> 'use_aws_owned_key')::bool and (arguments -> 'encryption_option' ->> 'kms_key_id') is null) then ' not encrypted with KMS CMK'
+      address || case
+        when ((attributes_std -> 'encryption_option' ->> 'use_aws_owned_key')::bool and (attributes_std -> 'encryption_option' ->> 'kms_key_id') is null) then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -43,13 +43,13 @@ query "mq_broker_encrypted_with_kms_cmk" {
 query "mq_broker_general_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logs' ->> 'general')::bool then 'ok'
+        when (attributes_std -> 'logs' ->> 'general')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'logs' ->> 'general')::bool is null then ' general logging enabled'
+      address || case
+        when (attributes_std -> 'logs' ->> 'general')::bool is null then ' general logging enabled'
         else ' general logging disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -64,13 +64,13 @@ query "mq_broker_general_logging_enabled" {
 query "mq_broker_automatic_minor_upgrade_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'auto_minor_version_upgrade')::bool then 'ok'
+        when (attributes_std ->> 'auto_minor_version_upgrade')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'auto_minor_version_upgrade')::bool then ' automatic minor version upgrade enabled'
+      address || case
+        when (attributes_std ->> 'auto_minor_version_upgrade')::bool then ' automatic minor version upgrade enabled'
         else ' automatic minor version upgrade disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -85,13 +85,13 @@ query "mq_broker_automatic_minor_upgrade_enabled" {
 query "mq_broker_publicly_accessible" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'publicly_accessible')::bool then 'alarm'
+        when (attributes_std ->> 'publicly_accessible')::bool then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments ->> 'publicly_accessible')::bool then ' is publicly accessible'
+      address || case
+        when (attributes_std ->> 'publicly_accessible')::bool then ' is publicly accessible'
         else ' is not publicly accessible'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -106,15 +106,15 @@ query "mq_broker_publicly_accessible" {
 query "mq_broker_currect_broker_version" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments ->> 'engine_type') = 'ActiveMQ' and (regexp_split_to_array(arguments ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('5.16', '\.')::int[])) then 'ok'
-        when ((arguments ->> 'engine_type') = 'RabbitMQ' and (regexp_split_to_array(arguments ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('3.8', '\.')::int[])) then 'ok'
+        when ((attributes_std ->> 'engine_type') = 'ActiveMQ' and (regexp_split_to_array(attributes_std ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('5.16', '\.')::int[])) then 'ok'
+        when ((attributes_std ->> 'engine_type') = 'RabbitMQ' and (regexp_split_to_array(attributes_std ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('3.8', '\.')::int[])) then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when ((arguments ->> 'engine_type') = 'ActiveMQ' and (regexp_split_to_array(arguments ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('5.16', '\.')::int[])) then ' uses current broker version'
-        when ((arguments ->> 'engine_type') = 'RabbitMQ' and (regexp_split_to_array(arguments ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('3.8', '\.')::int[])) then ' uses current broker version'
+      address || case
+        when ((attributes_std ->> 'engine_type') = 'ActiveMQ' and (regexp_split_to_array(attributes_std ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('5.16', '\.')::int[])) then ' uses current broker version'
+        when ((attributes_std ->> 'engine_type') = 'RabbitMQ' and (regexp_split_to_array(attributes_std ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('3.8', '\.')::int[])) then ' uses current broker version'
         else ' does not use current broker version'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/mqbroker.sp
+++ b/query/mqbroker.sp
@@ -6,7 +6,7 @@ query "mq_broker_audit_logging_enabled" {
         when ((attributes_std ->> 'engine_type') = 'RabbitMQ') and (attributes_std -> 'logs' ->> 'audit')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std ->> 'engine_type') = 'RabbitMQ') and (attributes_std -> 'logs' ->> 'audit')::bool is null then ' audit logging enabled'
         else ' audit logging disabled'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "mq_broker_encrypted_with_kms_cmk" {
         when ((attributes_std -> 'encryption_option' ->> 'use_aws_owned_key')::bool and (attributes_std -> 'encryption_option' ->> 'kms_key_id') is null) then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std -> 'encryption_option' ->> 'use_aws_owned_key')::bool and (attributes_std -> 'encryption_option' ->> 'kms_key_id') is null) then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
@@ -48,7 +48,7 @@ query "mq_broker_general_logging_enabled" {
         when (attributes_std -> 'logs' ->> 'general')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'logs' ->> 'general')::bool is null then ' general logging enabled'
         else ' general logging disabled'
       end || '.' as reason
@@ -69,7 +69,7 @@ query "mq_broker_automatic_minor_upgrade_enabled" {
         when (attributes_std ->> 'auto_minor_version_upgrade')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'auto_minor_version_upgrade')::bool then ' automatic minor version upgrade enabled'
         else ' automatic minor version upgrade disabled'
       end || '.' as reason
@@ -90,7 +90,7 @@ query "mq_broker_publicly_accessible" {
         when (attributes_std ->> 'publicly_accessible')::bool then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'publicly_accessible')::bool then ' is publicly accessible'
         else ' is not publicly accessible'
       end || '.' as reason
@@ -112,7 +112,7 @@ query "mq_broker_currect_broker_version" {
         when ((attributes_std ->> 'engine_type') = 'RabbitMQ' and (regexp_split_to_array(attributes_std ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('3.8', '\.')::int[])) then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std ->> 'engine_type') = 'ActiveMQ' and (regexp_split_to_array(attributes_std ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('5.16', '\.')::int[])) then ' uses current broker version'
         when ((attributes_std ->> 'engine_type') = 'RabbitMQ' and (regexp_split_to_array(attributes_std ->> 'engine_version', '\.')::int[] >= regexp_split_to_array('3.8', '\.')::int[])) then ' uses current broker version'
         else ' does not use current broker version'

--- a/query/msk.sp
+++ b/query/msk.sp
@@ -1,13 +1,13 @@
 query "msk_cluster_nodes_publicly_accessible" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'broker_node_group_info' -> 'connectivity_info' -> 'public_access' ->> 'type') = 'SERVICE_PROVIDED_EIPS' then 'alarm'
+        when (attributes_std -> 'broker_node_group_info' -> 'connectivity_info' -> 'public_access' ->> 'type') = 'SERVICE_PROVIDED_EIPS' then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'broker_node_group_info' -> 'connectivity_info' -> 'public_access' ->> 'type') = 'SERVICE_PROVIDED_EIPS' then ' cluster nodes are public'
+      address || case
+        when (attributes_std -> 'broker_node_group_info' -> 'connectivity_info' -> 'public_access' ->> 'type') = 'SERVICE_PROVIDED_EIPS' then ' cluster nodes are public'
         else ' cluster nodes are private'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "msk_cluster_nodes_publicly_accessible" {
 query "msk_cluster_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments -> 'logging_info' -> 'broker_logs' -> 'cloudwatch_logs' ->> 'enabled')::bool or (arguments -> 'logging_info' -> 'broker_logs' -> 'firehose' ->> 'enabled')::bool or (arguments -> 'logging_info' -> 'broker_logs' -> 's3' ->> 'enabled')::bool) then 'ok'
+        when ((attributes_std -> 'logging_info' -> 'broker_logs' -> 'cloudwatch_logs' ->> 'enabled')::bool or (attributes_std -> 'logging_info' -> 'broker_logs' -> 'firehose' ->> 'enabled')::bool or (attributes_std -> 'logging_info' -> 'broker_logs' -> 's3' ->> 'enabled')::bool) then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when ((arguments -> 'logging_info' -> 'broker_logs' -> 'cloudwatch_logs' ->> 'enabled')::bool or (arguments -> 'logging_info' -> 'broker_logs' -> 'firehose' ->> 'enabled')::bool or (arguments -> 'logging_info' -> 'broker_logs' -> 's3' ->> 'enabled')::bool) then ' logging enabled'
+      address || case
+        when ((attributes_std -> 'logging_info' -> 'broker_logs' -> 'cloudwatch_logs' ->> 'enabled')::bool or (attributes_std -> 'logging_info' -> 'broker_logs' -> 'firehose' ->> 'enabled')::bool or (attributes_std -> 'logging_info' -> 'broker_logs' -> 's3' ->> 'enabled')::bool) then ' logging enabled'
         else ' logging disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -43,15 +43,15 @@ query "msk_cluster_logging_enabled" {
 query "msk_cluster_encryption_in_transit_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encryption_info') is null then 'alarm'
-        when ((arguments -> 'encryption_info' ->> 'client_broker') = 'TLS' and (arguments -> 'encryption_info' ->> 'in_cluster')::bool) then 'ok'
+        when (attributes_std -> 'encryption_info') is null then 'alarm'
+        when ((attributes_std -> 'encryption_info' ->> 'client_broker') = 'TLS' and (attributes_std -> 'encryption_info' ->> 'in_cluster')::bool) then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'encryption_info') is null then ' not encrypted'
-        when ((arguments -> 'encryption_info' ->> 'client_broker') = 'TLS' and (arguments -> 'encryption_info' ->> 'in_cluster')::bool) then ' encryption in transit enabled'
+      address || case
+        when (attributes_std -> 'encryption_info') is null then ' not encrypted'
+        when ((attributes_std -> 'encryption_info' ->> 'client_broker') = 'TLS' and (attributes_std -> 'encryption_info' ->> 'in_cluster')::bool) then ' encryption in transit enabled'
         else ' encryption in transit disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -66,13 +66,13 @@ query "msk_cluster_encryption_in_transit_enabled" {
 query "msk_cluster_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encryption_at_rest_kms_key_arn') is null then 'alarm'
+        when (attributes_std -> 'encryption_at_rest_kms_key_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'encryption_at_rest_kms_key_arn') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'encryption_at_rest_kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/msk.sp
+++ b/query/msk.sp
@@ -6,7 +6,7 @@ query "msk_cluster_nodes_publicly_accessible" {
         when (attributes_std -> 'broker_node_group_info' -> 'connectivity_info' -> 'public_access' ->> 'type') = 'SERVICE_PROVIDED_EIPS' then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'broker_node_group_info' -> 'connectivity_info' -> 'public_access' ->> 'type') = 'SERVICE_PROVIDED_EIPS' then ' cluster nodes are public'
         else ' cluster nodes are private'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "msk_cluster_logging_enabled" {
         when ((attributes_std -> 'logging_info' -> 'broker_logs' -> 'cloudwatch_logs' ->> 'enabled')::bool or (attributes_std -> 'logging_info' -> 'broker_logs' -> 'firehose' ->> 'enabled')::bool or (attributes_std -> 'logging_info' -> 'broker_logs' -> 's3' ->> 'enabled')::bool) then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std -> 'logging_info' -> 'broker_logs' -> 'cloudwatch_logs' ->> 'enabled')::bool or (attributes_std -> 'logging_info' -> 'broker_logs' -> 'firehose' ->> 'enabled')::bool or (attributes_std -> 'logging_info' -> 'broker_logs' -> 's3' ->> 'enabled')::bool) then ' logging enabled'
         else ' logging disabled'
       end || '.' as reason
@@ -49,7 +49,7 @@ query "msk_cluster_encryption_in_transit_enabled" {
         when ((attributes_std -> 'encryption_info' ->> 'client_broker') = 'TLS' and (attributes_std -> 'encryption_info' ->> 'in_cluster')::bool) then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encryption_info') is null then ' not encrypted'
         when ((attributes_std -> 'encryption_info' ->> 'client_broker') = 'TLS' and (attributes_std -> 'encryption_info' ->> 'in_cluster')::bool) then ' encryption in transit enabled'
         else ' encryption in transit disabled'
@@ -71,7 +71,7 @@ query "msk_cluster_encrypted_with_kms_cmk" {
         when (attributes_std -> 'encryption_at_rest_kms_key_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encryption_at_rest_kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason

--- a/query/mwaa.sp
+++ b/query/mwaa.sp
@@ -1,13 +1,13 @@
 query "mwaa_environment_worker_logs_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logging_configuration' -> 'worker_logs' ->> 'enabled')::boolean then 'ok'
+        when (attributes_std -> 'logging_configuration' -> 'worker_logs' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'logging_configuration' -> 'worker_logs' ->> 'enabled')::boolean then ' worker logs enabled'
+      address || case
+        when (attributes_std -> 'logging_configuration' -> 'worker_logs' ->> 'enabled')::boolean then ' worker logs enabled'
         else ' worker logs disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "mwaa_environment_worker_logs_enabled" {
 query "mwaa_environment_webserver_logs_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logging_configuration' -> 'webserver_logs' ->> 'enabled')::boolean then 'ok'
+        when (attributes_std -> 'logging_configuration' -> 'webserver_logs' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'logging_configuration' -> 'webserver_logs' ->> 'enabled')::boolean then ' webserver logs enabled'
+      address || case
+        when (attributes_std -> 'logging_configuration' -> 'webserver_logs' ->> 'enabled')::boolean then ' webserver logs enabled'
         else ' webserver logs disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -43,13 +43,13 @@ query "mwaa_environment_webserver_logs_enabled" {
 query "mwaa_environment_scheduler_logs_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logging_configuration' -> 'scheduler_logs' ->> 'enabled')::boolean then 'ok'
+        when (attributes_std -> 'logging_configuration' -> 'scheduler_logs' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'logging_configuration' -> 'scheduler_logs' ->> 'enabled')::boolean then ' scheduler logs enabled'
+      address || case
+        when (attributes_std -> 'logging_configuration' -> 'scheduler_logs' ->> 'enabled')::boolean then ' scheduler logs enabled'
         else ' scheduler logs disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/mwaa.sp
+++ b/query/mwaa.sp
@@ -6,7 +6,7 @@ query "mwaa_environment_worker_logs_enabled" {
         when (attributes_std -> 'logging_configuration' -> 'worker_logs' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'logging_configuration' -> 'worker_logs' ->> 'enabled')::boolean then ' worker logs enabled'
         else ' worker logs disabled'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "mwaa_environment_webserver_logs_enabled" {
         when (attributes_std -> 'logging_configuration' -> 'webserver_logs' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'logging_configuration' -> 'webserver_logs' ->> 'enabled')::boolean then ' webserver logs enabled'
         else ' webserver logs disabled'
       end || '.' as reason
@@ -48,7 +48,7 @@ query "mwaa_environment_scheduler_logs_enabled" {
         when (attributes_std -> 'logging_configuration' -> 'scheduler_logs' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'logging_configuration' -> 'scheduler_logs' ->> 'enabled')::boolean then ' scheduler logs enabled'
         else ' scheduler logs disabled'
       end || '.' as reason

--- a/query/neptune.sp
+++ b/query/neptune.sp
@@ -6,7 +6,7 @@ query "neptune_cluster_encryption_at_rest_enabled" {
         when (attributes_std ->> 'storage_encrypted')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'storage_encrypted')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "neptune_cluster_logging_enabled" {
         when (attributes_std -> 'enable_cloudwatch_logs_exports') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'enable_cloudwatch_logs_exports') is null then ' logging not enabled'
         else ' logging enabled'
       end || '.' as reason
@@ -48,7 +48,7 @@ query "neptune_cluster_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
@@ -69,7 +69,7 @@ query "neptune_cluster_instance_publicly_accessible" {
         when (attributes_std ->> 'publicly_accessible')::boolean then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'publicly_accessible')::boolean then ' publicly accessible'
         else ' not publicly accessible'
       end || '.' as reason
@@ -90,7 +90,7 @@ query "neptune_snapshot_storage_encryption_enabled" {
         when (attributes_std ->> 'storage_encrypted')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'storage_encrypted')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason
@@ -111,7 +111,7 @@ query "neptune_snapshot_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason

--- a/query/neptune.sp
+++ b/query/neptune.sp
@@ -1,13 +1,13 @@
 query "neptune_cluster_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'storage_encrypted')::boolean then 'ok'
+        when (attributes_std ->> 'storage_encrypted')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'storage_encrypted')::boolean then ' encrypted at rest'
+      address || case
+        when (attributes_std ->> 'storage_encrypted')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "neptune_cluster_encryption_at_rest_enabled" {
 query "neptune_cluster_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'enable_cloudwatch_logs_exports') is null then 'alarm'
+        when (attributes_std -> 'enable_cloudwatch_logs_exports') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'enable_cloudwatch_logs_exports') is null then ' logging not enabled'
+      address || case
+        when (attributes_std -> 'enable_cloudwatch_logs_exports') is null then ' logging not enabled'
         else ' logging enabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -43,13 +43,13 @@ query "neptune_cluster_logging_enabled" {
 query "neptune_cluster_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_arn') is null then 'alarm'
+        when (attributes_std -> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -64,13 +64,13 @@ query "neptune_cluster_encrypted_with_kms_cmk" {
 query "neptune_cluster_instance_publicly_accessible" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'publicly_accessible')::boolean then 'alarm'
+        when (attributes_std ->> 'publicly_accessible')::boolean then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments ->> 'publicly_accessible')::boolean then ' publicly accessible'
+      address || case
+        when (attributes_std ->> 'publicly_accessible')::boolean then ' publicly accessible'
         else ' not publicly accessible'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -85,13 +85,13 @@ query "neptune_cluster_instance_publicly_accessible" {
 query "neptune_snapshot_storage_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'storage_encrypted')::boolean then 'ok'
+        when (attributes_std ->> 'storage_encrypted')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'storage_encrypted')::boolean then ' encrypted at rest'
+      address || case
+        when (attributes_std ->> 'storage_encrypted')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -106,13 +106,13 @@ query "neptune_snapshot_storage_encryption_enabled" {
 query "neptune_snapshot_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_id') is null then 'alarm'
+        when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kms_key_id') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/opensearch.sp
+++ b/query/opensearch.sp
@@ -2,13 +2,13 @@
 query "opensearch_domain_use_default_security_group" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'vpc_options' ->> 'security_group_ids') is not null then 'ok'
+        when (attributes_std -> 'vpc_options' ->> 'security_group_ids') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'vpc_options' ->> 'security_group_ids') is not null then ' default security group not set'
+      address || case
+        when (attributes_std -> 'vpc_options' ->> 'security_group_ids') is not null then ' default security group not set'
         else ' default security group set'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -23,13 +23,13 @@ query "opensearch_domain_use_default_security_group" {
 query "opensearch_domain_enforce_https" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'domain_endpoint_options' ->> 'enforce_https')::boolean is not null then 'ok'
+        when (attributes_std -> 'domain_endpoint_options' ->> 'enforce_https')::boolean is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'domain_endpoint_options' ->> 'enforce_https')::boolean then ' enforces HTTPS'
+      address || case
+        when (attributes_std -> 'domain_endpoint_options' ->> 'enforce_https')::boolean then ' enforces HTTPS'
         else ' does not enforce HTTPS'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -44,13 +44,13 @@ query "opensearch_domain_enforce_https" {
 query "opensearch_domain_encrpted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encrypt_at_rest' ->> 'kms_key_id') is not null then 'ok'
+        when (attributes_std -> 'encrypt_at_rest' ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'encrypt_at_rest' ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'encrypt_at_rest' ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/opensearch.sp
+++ b/query/opensearch.sp
@@ -7,7 +7,7 @@ query "opensearch_domain_use_default_security_group" {
         when (attributes_std -> 'vpc_options' ->> 'security_group_ids') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'vpc_options' ->> 'security_group_ids') is not null then ' default security group not set'
         else ' default security group set'
       end || '.' reason
@@ -28,7 +28,7 @@ query "opensearch_domain_enforce_https" {
         when (attributes_std -> 'domain_endpoint_options' ->> 'enforce_https')::boolean is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'domain_endpoint_options' ->> 'enforce_https')::boolean then ' enforces HTTPS'
         else ' does not enforce HTTPS'
       end || '.' reason
@@ -49,7 +49,7 @@ query "opensearch_domain_encrpted_with_kms_cmk" {
         when (attributes_std -> 'encrypt_at_rest' ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encrypt_at_rest' ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' reason

--- a/query/qldb.sp
+++ b/query/qldb.sp
@@ -6,7 +6,7 @@ query "qldb_ledger_deletion_protection_enabled" {
         when (attributes_std ->> 'deletion_protection') is null or (attributes_std ->> 'deletion_protection')::bool then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'deletion_protection') is null or (attributes_std ->> 'deletion_protection')::bool then ' deletion protection enabled'
         else ' deletion protection disabled'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "qldb_ledger_permission_mode_set_to_standard" {
         when (attributes_std ->> 'permissions_mode') = 'STANDARD' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'permissions_mode') = 'STANDARD' then ' permission mode set to "STANDARD"'
         else ' permission mode set to "ALLOW_ALL"'
       end || '.' as reason

--- a/query/qldb.sp
+++ b/query/qldb.sp
@@ -1,13 +1,13 @@
 query "qldb_ledger_deletion_protection_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'deletion_protection') is null or (arguments ->> 'deletion_protection')::bool then 'ok'
+        when (attributes_std ->> 'deletion_protection') is null or (attributes_std ->> 'deletion_protection')::bool then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'deletion_protection') is null or (arguments ->> 'deletion_protection')::bool then ' deletion protection enabled'
+      address || case
+        when (attributes_std ->> 'deletion_protection') is null or (attributes_std ->> 'deletion_protection')::bool then ' deletion protection enabled'
         else ' deletion protection disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "qldb_ledger_deletion_protection_enabled" {
 query "qldb_ledger_permission_mode_set_to_standard" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'permissions_mode') = 'STANDARD' then 'ok'
+        when (attributes_std ->> 'permissions_mode') = 'STANDARD' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'permissions_mode') = 'STANDARD' then ' permission mode set to "STANDARD"'
+      address || case
+        when (attributes_std ->> 'permissions_mode') = 'STANDARD' then ' permission mode set to "STANDARD"'
         else ' permission mode set to "ALLOW_ALL"'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/rds.sp
+++ b/query/rds.sp
@@ -295,7 +295,7 @@ query "rds_db_instance_and_cluster_no_default_port" {
         case
           when (attributes_std -> 'engine') is null and (attributes_std -> 'port') is null then 'alarm'
           when (attributes_std ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((attributes_std ->> 'port')::int = 3306 or (attributes_std -> 'port') is null) then 'alarm'
-          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432  or (attributes_std -> 'port') is null) then 'alarm'
+          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432 or (attributes_std -> 'port') is null) then 'alarm'
           when (attributes_std ->> 'engine') like 'oracle%' and ((attributes_std ->> 'port')::int = 1521 or (attributes_std -> 'port') is null) then 'alarm'
           when (attributes_std ->> 'engine') like 'sqlserver%' and ((attributes_std ->> 'port')::int = 1433 or (attributes_std -> 'port') is null) then 'alarm'
           else 'ok'
@@ -303,7 +303,7 @@ query "rds_db_instance_and_cluster_no_default_port" {
         split_part(address, '.', 2) || case
           when (attributes_std -> 'engine') is null and (attributes_std -> 'port') is null then ' uses a default port'
           when (attributes_std ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((attributes_std ->> 'port')::int = 3306 or (attributes_std -> 'port') is null) then ' uses a default port'
-          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432  or (attributes_std -> 'port') is null) then ' uses a default port'
+          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432 or (attributes_std -> 'port') is null) then ' uses a default port'
           when (attributes_std ->> 'engine') like 'oracle%' and ((attributes_std ->> 'port')::int = 1521 or (attributes_std -> 'port') is null) then ' uses a default port'
           when (attributes_std ->> 'engine') like 'sqlserver%' and ((attributes_std ->> 'port')::int = 1433 or (attributes_std -> 'port') is null) then ' uses a default port'
           else ' does not use a default port'
@@ -321,14 +321,14 @@ query "rds_db_instance_and_cluster_no_default_port" {
         address as resource,
         case
           when (attributes_std ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((attributes_std ->> 'port')::int = 3306 or (attributes_std -> 'port') is null) then 'alarm'
-          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432  or (attributes_std -> 'port') is null) then 'alarm'
+          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432 or (attributes_std -> 'port') is null) then 'alarm'
           when (attributes_std ->> 'engine') like 'oracle%' and ((attributes_std ->> 'port')::int = 1521 or (attributes_std -> 'port') is null) then 'alarm'
           when (attributes_std ->> 'engine') like 'sqlserver%' and ((attributes_std ->> 'port')::int = 1433 or (attributes_std -> 'port') is null) then 'alarm'
           else 'ok'
         end status,
         split_part(address, '.', 2) || case
           when (attributes_std ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((attributes_std ->> 'port')::int = 3306 or (attributes_std -> 'port') is null) then ' uses a default port'
-          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432  or (attributes_std -> 'port') is null) then ' uses a default port'
+          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432 or (attributes_std -> 'port') is null) then ' uses a default port'
           when (attributes_std ->> 'engine') like 'oracle%' and ((attributes_std ->> 'port')::int = 1521 or (attributes_std -> 'port') is null) then ' uses a default port'
           when (attributes_std ->> 'engine') like 'sqlserver%' and ((attributes_std ->> 'port')::int = 1433 or (attributes_std -> 'port') is null) then ' uses a default port'
           else ' does not use a default port'

--- a/query/rds.sp
+++ b/query/rds.sp
@@ -7,7 +7,7 @@ query "rds_db_cluster_aurora_backtracking_enabled" {
         when (attributes_std -> 'backtrack_window') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'engine') not like any (array ['%aurora%', '%aurora-mysql%']) then ' not Aurora MySQL-compatible edition'
         when (attributes_std -> 'backtrack_window') is not null then ' backtracking enabled'
         else ' backtracking disabled'
@@ -30,7 +30,7 @@ query "rds_db_cluster_copy_tags_to_snapshot_enabled" {
         when (attributes_std -> 'copy_tags_to_snapshot')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'copy_tags_to_snapshot') is null then ' ''copy_tags_to_snapshot'' disabled'
         when (attributes_std -> 'copy_tags_to_snapshot')::bool then ' ''copy_tags_to_snapshot'' enabled'
         else ' ''copy_tags_to_snapshot'' disabled'
@@ -53,7 +53,7 @@ query "rds_db_cluster_deletion_protection_enabled" {
         when (attributes_std -> 'deletion_protection')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'deletion_protection') is null then ' ''deletion_protection'' disabled'
         when (attributes_std -> 'deletion_protection')::boolean then ' ''deletion_protection'' enabled'
         else ' ''deletion_protection'' disabled'
@@ -76,7 +76,7 @@ query "rds_db_cluster_events_subscription" {
         when (attributes_std ->> 'source_type') = 'db-cluster' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'source_type') <> 'db-cluster' then ' event subscription of ' || (attributes_std ->> 'source_type') || ' type'
         when (attributes_std ->> 'source_type') = 'db-cluster' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then ' event subscription enabled for critical db cluster events'
         else ' event subscription missing critical db cluster events'
@@ -99,7 +99,7 @@ query "rds_db_cluster_iam_authentication_enabled" {
         when (attributes_std -> 'iam_database_authentication_enabled')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'iam_database_authentication_enabled') is null then ' ''iam_database_authentication_enabled'' disabled'
         when (attributes_std -> 'iam_database_authentication_enabled')::bool then ' ''iam_database_authentication_enabled'' enabled'
         else ' ''iam_database_authentication_enabled'' disabled'
@@ -122,7 +122,7 @@ query "rds_db_cluster_multiple_az_enabled" {
         when (attributes_std -> 'multi_az')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'multi_az') is null then ' ''multi_az'' disabled'
         when (attributes_std -> 'multi_az')::boolean then ' ''multi_az'' enabled'
         else ' ''multi_az'' disabled'
@@ -145,7 +145,7 @@ query "rds_db_cluster_instance_performance_insights_enabled" {
         when (attributes_std -> 'performance_insights_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'performance_insights_enabled') is null then ' performance insights disabled'
         when (attributes_std -> 'performance_insights_enabled')::boolean then ' performance insights enabled'
         else ' performance insights disabled'
@@ -167,7 +167,7 @@ query "rds_db_cluster_instance_performance_insights_encrypted_with_kms_cmk" {
         when (attributes_std -> 'performance_insights_kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'performance_insights_kms_key_id') is null then ' performance insights not encrypted with KMS CMK'
         else ' performance insights encrypted with KMS CMK'
       end || '.' as reason
@@ -188,7 +188,7 @@ query "rds_db_instance_performance_insights_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'performance_insights_kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'performance_insights_kms_key_id') is null then ' performance insights not encrypted with kms key'
         else ' performance insights encrypted with kms key'
       end || '.' as reason
@@ -210,7 +210,7 @@ query "rds_db_instance_performance_insights_enabled" {
         when (attributes_std ->> 'performance_insights_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'performance_insights_enabled') is null then ' performance insights disabled'
         when (attributes_std ->> 'performance_insights_enabled')::boolean then ' performance insights enabled'
         else ' performance insights disabled'
@@ -233,7 +233,7 @@ query "rds_db_instance_and_cluster_enhanced_monitoring_enabled" {
           when (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null then 'ok'
           else 'alarm'
         end status,
-        address || case
+        split_part(address, '.', 2) || case
           when (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null then ' ''enabled_cloudwatch_logs_exports'' enabled'
           else ' ''enabled_cloudwatch_logs_exports'' disabled'
         end || '.' reason
@@ -252,7 +252,7 @@ query "rds_db_instance_and_cluster_enhanced_monitoring_enabled" {
           when (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null then 'ok'
           else 'alarm'
         end status,
-        address || case
+        split_part(address, '.', 2) || case
           when (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null then ' ''enabled_cloudwatch_logs_exports'' enabled'
           else ' ''enabled_cloudwatch_logs_exports'' disabled'
         end || '.' reason
@@ -274,7 +274,7 @@ query "rds_cluster_activity_stream_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
@@ -300,7 +300,7 @@ query "rds_db_instance_and_cluster_no_default_port" {
           when (attributes_std ->> 'engine') like 'sqlserver%' and ((attributes_std ->> 'port')::int = 1433 or (attributes_std -> 'port') is null) then 'alarm'
           else 'ok'
         end status,
-        address || case
+        split_part(address, '.', 2) || case
           when (attributes_std -> 'engine') is null and (attributes_std -> 'port') is null then ' uses a default port'
           when (attributes_std ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((attributes_std ->> 'port')::int = 3306 or (attributes_std -> 'port') is null) then ' uses a default port'
           when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432  or (attributes_std -> 'port') is null) then ' uses a default port'
@@ -326,7 +326,7 @@ query "rds_db_instance_and_cluster_no_default_port" {
           when (attributes_std ->> 'engine') like 'sqlserver%' and ((attributes_std ->> 'port')::int = 1433 or (attributes_std -> 'port') is null) then 'alarm'
           else 'ok'
         end status,
-        address || case
+        split_part(address, '.', 2) || case
           when (attributes_std ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((attributes_std ->> 'port')::int = 3306 or (attributes_std -> 'port') is null) then ' uses a default port'
           when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432  or (attributes_std -> 'port') is null) then ' uses a default port'
           when (attributes_std ->> 'engine') like 'oracle%' and ((attributes_std ->> 'port')::int = 1521 or (attributes_std -> 'port') is null) then ' uses a default port'
@@ -351,7 +351,7 @@ query "rds_db_cluster_encrypted_with_kms_cmk" {
         when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
@@ -373,7 +373,7 @@ query "rds_db_instance_automatic_minor_version_upgrade_enabled" {
         when (attributes_std -> 'auto_minor_version_upgrade')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'auto_minor_version_upgrade') is null then ' ''auto_minor_version_upgrade'' enabled'
         when (attributes_std -> 'deletion_protection')::boolean then ' ''auto_minor_version_upgrade'' enabled'
         else ' ''auto_minor_version_upgrade'' disabled'
@@ -396,7 +396,7 @@ query "rds_db_instance_backup_enabled" {
         when (attributes_std -> 'backup_retention_period')::integer < 1 then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'backup_retention_period') is null then ' backup disabled'
         when (attributes_std -> 'backup_retention_period')::integer < 1 then ' backup disabled'
         else ' backup enabled'
@@ -419,7 +419,7 @@ query "rds_db_instance_copy_tags_to_snapshot_enabled" {
         when (attributes_std -> 'copy_tags_to_snapshot')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'copy_tags_to_snapshot') is null then ' ''copy_tags_to_snapshot'' disabled'
         when (attributes_std -> 'copy_tags_to_snapshot')::bool then ' ''copy_tags_to_snapshot'' enabled'
         else ' ''copy_tags_to_snapshot'' disabled'
@@ -442,7 +442,7 @@ query "rds_db_instance_deletion_protection_enabled" {
         when (attributes_std -> 'deletion_protection')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'deletion_protection') is null then ' ''deletion_protection'' disabled'
         when (attributes_std -> 'deletion_protection')::bool then ' ''deletion_protection'' enabled'
         else ' ''deletion_protection'' disabled'
@@ -465,7 +465,7 @@ query "rds_db_instance_encryption_at_rest_enabled" {
         when (attributes_std -> 'storage_encrypted')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'storage_encrypted') is null then ' not encrypted'
         when (attributes_std -> 'storage_encrypted')::bool then ' encrypted'
         else ' not encrypted'
@@ -488,7 +488,7 @@ query "rds_db_instance_events_subscription" {
         when (attributes_std ->> 'source_type') = 'db-instance' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'source_type') <> 'db-instance' then ' event subscription of ' || (attributes_std ->> 'source_type') || ' type'
         when (attributes_std ->> 'source_type') = 'db-instance' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then ' event subscription enabled for critical db cluster events'
         else ' event subscription missing critical db instance events'
@@ -511,7 +511,7 @@ query "rds_db_instance_iam_authentication_enabled" {
         when (attributes_std -> 'iam_database_authentication_enabled')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'iam_database_authentication_enabled') is null then ' ''iam_database_authentication_enabled'' disabled'
         when (attributes_std -> 'iam_database_authentication_enabled')::bool then ' ''iam_database_authentication_enabled'' enabled'
         else ' ''iam_database_authentication_enabled'' disabled'
@@ -556,7 +556,7 @@ query "rds_db_instance_logging_enabled" {
           and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["error","agent"]' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when
           (attributes_std ->> 'engine')::text like any (array ['mariadb', '%mysql'])
           and (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
@@ -601,7 +601,7 @@ query "rds_db_instance_multiple_az_enabled" {
         when (attributes_std -> 'multi_az')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'multi_az') is null then ' ''multi_az'' disabled'
         when (attributes_std -> 'multi_az')::boolean then ' ''multi_az'' enabled'
         else ' ''multi_az'' disabled'
@@ -624,7 +624,7 @@ query "rds_db_instance_prohibit_public_access" {
         when (attributes_std -> 'publicly_accessible')::boolean then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'publicly_accessible') is null then ' not publicly accessible'
         when (attributes_std -> 'publicly_accessible')::boolean then ' publicly accessible'
         else ' not publicly accessible'
@@ -647,7 +647,7 @@ query "rds_db_parameter_group_events_subscription" {
         when (attributes_std ->> 'source_type') = 'db-parameter-group' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'source_type') <> 'db-parameter-group' then ' event subscription of ' || (attributes_std ->> 'source_type') || ' type'
         when (attributes_std ->> 'source_type') = 'db-parameter-group' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then ' event subscription enabled for critical database parameter group events'
         else ' event subscription missing critical database parameter group events'
@@ -674,7 +674,7 @@ query "rds_db_security_group_events_subscription" {
           and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "configuration change"]'::jsonb then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'source_type') <> 'db-security-group' then ' event subscription of ' || (attributes_std ->> 'source_type') || ' type'
         when
           (attributes_std ->> 'source_type') = 'db-security-group'
@@ -700,7 +700,7 @@ query "rds_db_instance_uses_recent_ca_certificate" {
         when (attributes_std ->> 'ca_cert_identifier') is null then 'skip'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'ca_cert_identifier') in ('rds-ca-rsa2048-g1', 'rds-ca-rsa4096-g1', 'rds-ca-ecc384-g1') then ' uses recent CA certificate'
         when (attributes_std ->> 'ca_cert_identifier') is null then ' CA certificate not defined'
         else ' uses an old CA certificate'
@@ -722,7 +722,7 @@ query "memorydb_snapshot_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' reason
@@ -743,7 +743,7 @@ query "memorydb_cluster_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' reason
@@ -764,7 +764,7 @@ query "memorydb_cluster_transit_encryption_enabled" {
         when (attributes_std ->> 'tls_enabled') = 'false' then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'tls_enabled') = 'false' then ' encryption at transit disabled'
         else ' encryption at transit enabled'
       end || '.' reason
@@ -785,7 +785,7 @@ query "rds_db_snapshot_not_publicly_accesible" {
         when (attributes_std -> 'shared_accounts') @> '["all"]' then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'shared_accounts') @> '["all"]' then ' publicly accessible'
         else ' not publicly accessible'
       end || '.' reason
@@ -806,7 +806,7 @@ query "rds_db_snapshot_copy_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' reason
@@ -827,7 +827,7 @@ query "rds_db_cluster_instance_automatic_minor_version_upgrade_enabled" {
         when (attributes_std ->> 'auto_minor_version_upgrade') = 'false' then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'auto_minor_version_upgrade') = 'false' then ' auto minor version upgrade disabled'
         else ' auto minor version upgrade enabled'
       end || '.' reason
@@ -848,7 +848,7 @@ query "rds_db_cluster_encryption_enabled" {
         when (attributes_std ->> 'storage_encrypted') = 'true' or (attributes_std ->> 'engine_mode') = 'serverless' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'storage_encrypted') = 'true' or (attributes_std ->> 'engine_mode') = 'serverless' then ' encryption enabled'
         else ' encryption disabled'
       end || '.' reason
@@ -870,7 +870,7 @@ query "rds_mysql_db_cluster_audit_logging_enabled" {
         when (attributes_std ->> 'engine')::text like '%mysql' and (attributes_std -> 'enabled_cloudwatch_logs_exports') @> '["audit"]' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'engine')::text not like '%mysql' then ' not a MySQL cluster'
         when (attributes_std ->> 'engine')::text like '%mysql' and (attributes_std -> 'enabled_cloudwatch_logs_exports') @> '["audit"]' then ' audit logging enabled'
         else ' audit logging disabled'
@@ -894,7 +894,7 @@ query "rds_global_cluster_encryption_enabled" {
         when (attributes_std ->> 'storage_encrypted')::boolean and (attributes_std ->> 'source_db_cluster_identifier') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'storage_encrypted')::boolean then ' enccryption enabled'
         when (attributes_std ->> 'source_db_cluster_identifier') is null then ' DB cluster identifier is not provided of the primary global cluster creation'
         when (attributes_std ->> 'storage_encrypted')::boolean and (attributes_std ->> 'source_db_cluster_identifier') is not null then ' enccryption enabled'

--- a/query/rds.sp
+++ b/query/rds.sp
@@ -1,15 +1,15 @@
 query "rds_db_cluster_aurora_backtracking_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'engine') not like any (array ['%aurora%', '%aurora-mysql%']) then 'skip'
-        when (arguments -> 'backtrack_window') is not null then 'ok'
+        when (attributes_std ->> 'engine') not like any (array ['%aurora%', '%aurora-mysql%']) then 'skip'
+        when (attributes_std -> 'backtrack_window') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'engine') not like any (array ['%aurora%', '%aurora-mysql%']) then ' not Aurora MySQL-compatible edition'
-        when (arguments -> 'backtrack_window') is not null then ' backtracking enabled'
+      address || case
+        when (attributes_std ->> 'engine') not like any (array ['%aurora%', '%aurora-mysql%']) then ' not Aurora MySQL-compatible edition'
+        when (attributes_std -> 'backtrack_window') is not null then ' backtracking enabled'
         else ' backtracking disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -24,15 +24,15 @@ query "rds_db_cluster_aurora_backtracking_enabled" {
 query "rds_db_cluster_copy_tags_to_snapshot_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'copy_tags_to_snapshot') is null then 'alarm'
-        when (arguments -> 'copy_tags_to_snapshot')::bool then 'ok'
+        when (attributes_std -> 'copy_tags_to_snapshot') is null then 'alarm'
+        when (attributes_std -> 'copy_tags_to_snapshot')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'copy_tags_to_snapshot') is null then ' ''copy_tags_to_snapshot'' disabled'
-        when (arguments -> 'copy_tags_to_snapshot')::bool then ' ''copy_tags_to_snapshot'' enabled'
+      address || case
+        when (attributes_std -> 'copy_tags_to_snapshot') is null then ' ''copy_tags_to_snapshot'' disabled'
+        when (attributes_std -> 'copy_tags_to_snapshot')::bool then ' ''copy_tags_to_snapshot'' enabled'
         else ' ''copy_tags_to_snapshot'' disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -47,15 +47,15 @@ query "rds_db_cluster_copy_tags_to_snapshot_enabled" {
 query "rds_db_cluster_deletion_protection_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'deletion_protection') is null then 'alarm'
-        when (arguments -> 'deletion_protection')::boolean then 'ok'
+        when (attributes_std -> 'deletion_protection') is null then 'alarm'
+        when (attributes_std -> 'deletion_protection')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'deletion_protection') is null then ' ''deletion_protection'' disabled'
-        when (arguments -> 'deletion_protection')::boolean then ' ''deletion_protection'' enabled'
+      address || case
+        when (attributes_std -> 'deletion_protection') is null then ' ''deletion_protection'' disabled'
+        when (attributes_std -> 'deletion_protection')::boolean then ' ''deletion_protection'' enabled'
         else ' ''deletion_protection'' disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -70,15 +70,15 @@ query "rds_db_cluster_deletion_protection_enabled" {
 query "rds_db_cluster_events_subscription" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'source_type') <> 'db-cluster' then 'skip'
-        when (arguments ->> 'source_type') = 'db-cluster' and (arguments -> 'enabled')::bool and (arguments -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (arguments -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then 'ok'
+        when (attributes_std ->> 'source_type') <> 'db-cluster' then 'skip'
+        when (attributes_std ->> 'source_type') = 'db-cluster' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'source_type') <> 'db-cluster' then ' event subscription of ' || (arguments ->> 'source_type') || ' type'
-        when (arguments ->> 'source_type') = 'db-cluster' and (arguments -> 'enabled')::bool and (arguments -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (arguments -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then ' event subscription enabled for critical db cluster events'
+      address || case
+        when (attributes_std ->> 'source_type') <> 'db-cluster' then ' event subscription of ' || (attributes_std ->> 'source_type') || ' type'
+        when (attributes_std ->> 'source_type') = 'db-cluster' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then ' event subscription enabled for critical db cluster events'
         else ' event subscription missing critical db cluster events'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -93,15 +93,15 @@ query "rds_db_cluster_events_subscription" {
 query "rds_db_cluster_iam_authentication_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'iam_database_authentication_enabled') is null then 'alarm'
-        when (arguments -> 'iam_database_authentication_enabled')::bool then 'ok'
+        when (attributes_std -> 'iam_database_authentication_enabled') is null then 'alarm'
+        when (attributes_std -> 'iam_database_authentication_enabled')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'iam_database_authentication_enabled') is null then ' ''iam_database_authentication_enabled'' disabled'
-        when (arguments -> 'iam_database_authentication_enabled')::bool then ' ''iam_database_authentication_enabled'' enabled'
+      address || case
+        when (attributes_std -> 'iam_database_authentication_enabled') is null then ' ''iam_database_authentication_enabled'' disabled'
+        when (attributes_std -> 'iam_database_authentication_enabled')::bool then ' ''iam_database_authentication_enabled'' enabled'
         else ' ''iam_database_authentication_enabled'' disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -116,15 +116,15 @@ query "rds_db_cluster_iam_authentication_enabled" {
 query "rds_db_cluster_multiple_az_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'multi_az') is null then 'alarm'
-        when (arguments -> 'multi_az')::boolean then 'ok'
+        when (attributes_std -> 'multi_az') is null then 'alarm'
+        when (attributes_std -> 'multi_az')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'multi_az') is null then ' ''multi_az'' disabled'
-        when (arguments -> 'multi_az')::boolean then ' ''multi_az'' enabled'
+      address || case
+        when (attributes_std -> 'multi_az') is null then ' ''multi_az'' disabled'
+        when (attributes_std -> 'multi_az')::boolean then ' ''multi_az'' enabled'
         else ' ''multi_az'' disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -139,15 +139,15 @@ query "rds_db_cluster_multiple_az_enabled" {
 query "rds_db_cluster_instance_performance_insights_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'performance_insights_enabled') is null then 'alarm'
-        when (arguments -> 'performance_insights_enabled')::boolean then 'ok'
+        when (attributes_std -> 'performance_insights_enabled') is null then 'alarm'
+        when (attributes_std -> 'performance_insights_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'performance_insights_enabled') is null then ' performance insights disabled'
-        when (arguments -> 'performance_insights_enabled')::boolean then ' performance insights enabled'
+      address || case
+        when (attributes_std -> 'performance_insights_enabled') is null then ' performance insights disabled'
+        when (attributes_std -> 'performance_insights_enabled')::boolean then ' performance insights enabled'
         else ' performance insights disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -162,13 +162,13 @@ query "rds_db_cluster_instance_performance_insights_enabled" {
 query "rds_db_cluster_instance_performance_insights_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'performance_insights_kms_key_id') is null then 'alarm'
+        when (attributes_std -> 'performance_insights_kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'performance_insights_kms_key_id') is null then ' performance insights not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'performance_insights_kms_key_id') is null then ' performance insights not encrypted with KMS CMK'
         else ' performance insights encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -183,13 +183,13 @@ query "rds_db_cluster_instance_performance_insights_encrypted_with_kms_cmk" {
 query "rds_db_instance_performance_insights_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'performance_insights_kms_key_id') is null then 'alarm'
+        when (attributes_std ->> 'performance_insights_kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments ->> 'performance_insights_kms_key_id') is null then ' performance insights not encrypted with kms key'
+      address || case
+        when (attributes_std ->> 'performance_insights_kms_key_id') is null then ' performance insights not encrypted with kms key'
         else ' performance insights encrypted with kms key'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -204,15 +204,15 @@ query "rds_db_instance_performance_insights_encrypted_with_kms_cmk" {
 query "rds_db_instance_performance_insights_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'performance_insights_enabled') is null then 'alarm'
-        when (arguments ->> 'performance_insights_enabled')::boolean then 'ok'
+        when (attributes_std ->> 'performance_insights_enabled') is null then 'alarm'
+        when (attributes_std ->> 'performance_insights_enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'performance_insights_enabled') is null then ' performance insights disabled'
-        when (arguments ->> 'performance_insights_enabled')::boolean then ' performance insights enabled'
+      address || case
+        when (attributes_std ->> 'performance_insights_enabled') is null then ' performance insights disabled'
+        when (attributes_std ->> 'performance_insights_enabled')::boolean then ' performance insights enabled'
         else ' performance insights disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -228,13 +228,13 @@ query "rds_db_instance_and_cluster_enhanced_monitoring_enabled" {
   sql = <<-EOQ
     (
       select
-        type || ' ' || name as resource,
+        address as resource,
         case
-          when (arguments -> 'enabled_cloudwatch_logs_exports') is not null then 'ok'
+          when (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null then 'ok'
           else 'alarm'
         end status,
-        name || case
-          when (arguments -> 'enabled_cloudwatch_logs_exports') is not null then ' ''enabled_cloudwatch_logs_exports'' enabled'
+        address || case
+          when (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null then ' ''enabled_cloudwatch_logs_exports'' enabled'
           else ' ''enabled_cloudwatch_logs_exports'' disabled'
         end || '.' reason
       ${local.tag_dimensions_sql}
@@ -247,13 +247,13 @@ query "rds_db_instance_and_cluster_enhanced_monitoring_enabled" {
     union
     (
       select
-        type || ' ' || name as resource,
+        address as resource,
         case
-          when (arguments -> 'enabled_cloudwatch_logs_exports') is not null then 'ok'
+          when (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null then 'ok'
           else 'alarm'
         end status,
-        name || case
-          when (arguments -> 'enabled_cloudwatch_logs_exports') is not null then ' ''enabled_cloudwatch_logs_exports'' enabled'
+        address || case
+          when (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null then ' ''enabled_cloudwatch_logs_exports'' enabled'
           else ' ''enabled_cloudwatch_logs_exports'' disabled'
         end || '.' reason
       ${local.tag_dimensions_sql}
@@ -269,13 +269,13 @@ query "rds_db_instance_and_cluster_enhanced_monitoring_enabled" {
 query "rds_cluster_activity_stream_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is null then 'alarm'
+        when (attributes_std ->> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments ->> 'kms_key_id') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -291,21 +291,21 @@ query "rds_db_instance_and_cluster_no_default_port" {
   sql = <<-EOQ
     (
       select
-        type || ' ' || name as resource,
+        address as resource,
         case
-          when (arguments -> 'engine') is null and (arguments -> 'port') is null then 'alarm'
-          when (arguments ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((arguments ->> 'port')::int = 3306 or (arguments -> 'port') is null) then 'alarm'
-          when (arguments ->> 'engine') like '%postgres%' and ((arguments ->> 'port')::int = 5432  or (arguments -> 'port') is null) then 'alarm'
-          when (arguments ->> 'engine') like 'oracle%' and ((arguments ->> 'port')::int = 1521 or (arguments -> 'port') is null) then 'alarm'
-          when (arguments ->> 'engine') like 'sqlserver%' and ((arguments ->> 'port')::int = 1433 or (arguments -> 'port') is null) then 'alarm'
+          when (attributes_std -> 'engine') is null and (attributes_std -> 'port') is null then 'alarm'
+          when (attributes_std ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((attributes_std ->> 'port')::int = 3306 or (attributes_std -> 'port') is null) then 'alarm'
+          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432  or (attributes_std -> 'port') is null) then 'alarm'
+          when (attributes_std ->> 'engine') like 'oracle%' and ((attributes_std ->> 'port')::int = 1521 or (attributes_std -> 'port') is null) then 'alarm'
+          when (attributes_std ->> 'engine') like 'sqlserver%' and ((attributes_std ->> 'port')::int = 1433 or (attributes_std -> 'port') is null) then 'alarm'
           else 'ok'
         end status,
-        name || case
-          when (arguments -> 'engine') is null and (arguments -> 'port') is null then ' uses a default port'
-          when (arguments ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((arguments ->> 'port')::int = 3306 or (arguments -> 'port') is null) then ' uses a default port'
-          when (arguments ->> 'engine') like '%postgres%' and ((arguments ->> 'port')::int = 5432  or (arguments -> 'port') is null) then ' uses a default port'
-          when (arguments ->> 'engine') like 'oracle%' and ((arguments ->> 'port')::int = 1521 or (arguments -> 'port') is null) then ' uses a default port'
-          when (arguments ->> 'engine') like 'sqlserver%' and ((arguments ->> 'port')::int = 1433 or (arguments -> 'port') is null) then ' uses a default port'
+        address || case
+          when (attributes_std -> 'engine') is null and (attributes_std -> 'port') is null then ' uses a default port'
+          when (attributes_std ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((attributes_std ->> 'port')::int = 3306 or (attributes_std -> 'port') is null) then ' uses a default port'
+          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432  or (attributes_std -> 'port') is null) then ' uses a default port'
+          when (attributes_std ->> 'engine') like 'oracle%' and ((attributes_std ->> 'port')::int = 1521 or (attributes_std -> 'port') is null) then ' uses a default port'
+          when (attributes_std ->> 'engine') like 'sqlserver%' and ((attributes_std ->> 'port')::int = 1433 or (attributes_std -> 'port') is null) then ' uses a default port'
           else ' does not use a default port'
         end || '.' reason
         ${local.tag_dimensions_sql}
@@ -318,19 +318,19 @@ query "rds_db_instance_and_cluster_no_default_port" {
     union
     (
       select
-        type || ' ' || name as resource,
+        address as resource,
         case
-          when (arguments ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((arguments ->> 'port')::int = 3306 or (arguments -> 'port') is null) then 'alarm'
-          when (arguments ->> 'engine') like '%postgres%' and ((arguments ->> 'port')::int = 5432  or (arguments -> 'port') is null) then 'alarm'
-          when (arguments ->> 'engine') like 'oracle%' and ((arguments ->> 'port')::int = 1521 or (arguments -> 'port') is null) then 'alarm'
-          when (arguments ->> 'engine') like 'sqlserver%' and ((arguments ->> 'port')::int = 1433 or (arguments -> 'port') is null) then 'alarm'
+          when (attributes_std ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((attributes_std ->> 'port')::int = 3306 or (attributes_std -> 'port') is null) then 'alarm'
+          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432  or (attributes_std -> 'port') is null) then 'alarm'
+          when (attributes_std ->> 'engine') like 'oracle%' and ((attributes_std ->> 'port')::int = 1521 or (attributes_std -> 'port') is null) then 'alarm'
+          when (attributes_std ->> 'engine') like 'sqlserver%' and ((attributes_std ->> 'port')::int = 1433 or (attributes_std -> 'port') is null) then 'alarm'
           else 'ok'
         end status,
-        name || case
-          when (arguments ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((arguments ->> 'port')::int = 3306 or (arguments -> 'port') is null) then ' uses a default port'
-          when (arguments ->> 'engine') like '%postgres%' and ((arguments ->> 'port')::int = 5432  or (arguments -> 'port') is null) then ' uses a default port'
-          when (arguments ->> 'engine') like 'oracle%' and ((arguments ->> 'port')::int = 1521 or (arguments -> 'port') is null) then ' uses a default port'
-          when (arguments ->> 'engine') like 'sqlserver%' and ((arguments ->> 'port')::int = 1433 or (arguments -> 'port') is null) then ' uses a default port'
+        address || case
+          when (attributes_std ->> 'engine') similar to '%(aurora|mysql|mariadb)%' and ((attributes_std ->> 'port')::int = 3306 or (attributes_std -> 'port') is null) then ' uses a default port'
+          when (attributes_std ->> 'engine') like '%postgres%' and ((attributes_std ->> 'port')::int = 5432  or (attributes_std -> 'port') is null) then ' uses a default port'
+          when (attributes_std ->> 'engine') like 'oracle%' and ((attributes_std ->> 'port')::int = 1521 or (attributes_std -> 'port') is null) then ' uses a default port'
+          when (attributes_std ->> 'engine') like 'sqlserver%' and ((attributes_std ->> 'port')::int = 1433 or (attributes_std -> 'port') is null) then ' uses a default port'
           else ' does not use a default port'
         end || '.' reason
         ${local.tag_dimensions_sql}
@@ -346,13 +346,13 @@ query "rds_db_instance_and_cluster_no_default_port" {
 query "rds_db_cluster_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_id') is null then 'alarm'
+        when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
+      address || case
+        when (attributes_std -> 'kms_key_id') is null then ' is not encrypted with KMS CMK'
         else ' is encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -367,15 +367,15 @@ query "rds_db_cluster_encrypted_with_kms_cmk" {
 query "rds_db_instance_automatic_minor_version_upgrade_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'auto_minor_version_upgrade') is null then 'ok'
-        when (arguments -> 'auto_minor_version_upgrade')::boolean then 'ok'
+        when (attributes_std -> 'auto_minor_version_upgrade') is null then 'ok'
+        when (attributes_std -> 'auto_minor_version_upgrade')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'auto_minor_version_upgrade') is null then ' ''auto_minor_version_upgrade'' enabled'
-        when (arguments -> 'deletion_protection')::boolean then ' ''auto_minor_version_upgrade'' enabled'
+      address || case
+        when (attributes_std -> 'auto_minor_version_upgrade') is null then ' ''auto_minor_version_upgrade'' enabled'
+        when (attributes_std -> 'deletion_protection')::boolean then ' ''auto_minor_version_upgrade'' enabled'
         else ' ''auto_minor_version_upgrade'' disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -390,15 +390,15 @@ query "rds_db_instance_automatic_minor_version_upgrade_enabled" {
 query "rds_db_instance_backup_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'backup_retention_period') is null then 'alarm'
-        when (arguments -> 'backup_retention_period')::integer < 1 then 'alarm'
+        when (attributes_std -> 'backup_retention_period') is null then 'alarm'
+        when (attributes_std -> 'backup_retention_period')::integer < 1 then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'backup_retention_period') is null then ' backup disabled'
-        when (arguments -> 'backup_retention_period')::integer < 1 then ' backup disabled'
+      address || case
+        when (attributes_std -> 'backup_retention_period') is null then ' backup disabled'
+        when (attributes_std -> 'backup_retention_period')::integer < 1 then ' backup disabled'
         else ' backup enabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -413,15 +413,15 @@ query "rds_db_instance_backup_enabled" {
 query "rds_db_instance_copy_tags_to_snapshot_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'copy_tags_to_snapshot') is null then 'alarm'
-        when (arguments -> 'copy_tags_to_snapshot')::bool then 'ok'
+        when (attributes_std -> 'copy_tags_to_snapshot') is null then 'alarm'
+        when (attributes_std -> 'copy_tags_to_snapshot')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'copy_tags_to_snapshot') is null then ' ''copy_tags_to_snapshot'' disabled'
-        when (arguments -> 'copy_tags_to_snapshot')::bool then ' ''copy_tags_to_snapshot'' enabled'
+      address || case
+        when (attributes_std -> 'copy_tags_to_snapshot') is null then ' ''copy_tags_to_snapshot'' disabled'
+        when (attributes_std -> 'copy_tags_to_snapshot')::bool then ' ''copy_tags_to_snapshot'' enabled'
         else ' ''copy_tags_to_snapshot'' disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -436,15 +436,15 @@ query "rds_db_instance_copy_tags_to_snapshot_enabled" {
 query "rds_db_instance_deletion_protection_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'deletion_protection') is null then 'alarm'
-        when (arguments -> 'deletion_protection')::bool then 'ok'
+        when (attributes_std -> 'deletion_protection') is null then 'alarm'
+        when (attributes_std -> 'deletion_protection')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'deletion_protection') is null then ' ''deletion_protection'' disabled'
-        when (arguments -> 'deletion_protection')::bool then ' ''deletion_protection'' enabled'
+      address || case
+        when (attributes_std -> 'deletion_protection') is null then ' ''deletion_protection'' disabled'
+        when (attributes_std -> 'deletion_protection')::bool then ' ''deletion_protection'' enabled'
         else ' ''deletion_protection'' disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -459,15 +459,15 @@ query "rds_db_instance_deletion_protection_enabled" {
 query "rds_db_instance_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'storage_encrypted') is null then 'alarm'
-        when (arguments -> 'storage_encrypted')::bool then 'ok'
+        when (attributes_std -> 'storage_encrypted') is null then 'alarm'
+        when (attributes_std -> 'storage_encrypted')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'storage_encrypted') is null then ' not encrypted'
-        when (arguments -> 'storage_encrypted')::bool then ' encrypted'
+      address || case
+        when (attributes_std -> 'storage_encrypted') is null then ' not encrypted'
+        when (attributes_std -> 'storage_encrypted')::bool then ' encrypted'
         else ' not encrypted'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -482,15 +482,15 @@ query "rds_db_instance_encryption_at_rest_enabled" {
 query "rds_db_instance_events_subscription" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'source_type') <> 'db-instance' then 'skip'
-        when (arguments ->> 'source_type') = 'db-instance' and (arguments -> 'enabled')::bool and (arguments -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (arguments -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then 'ok'
+        when (attributes_std ->> 'source_type') <> 'db-instance' then 'skip'
+        when (attributes_std ->> 'source_type') = 'db-instance' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'source_type') <> 'db-instance' then ' event subscription of ' || (arguments ->> 'source_type') || ' type'
-        when (arguments ->> 'source_type') = 'db-instance' and (arguments -> 'enabled')::bool and (arguments -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (arguments -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then ' event subscription enabled for critical db cluster events'
+      address || case
+        when (attributes_std ->> 'source_type') <> 'db-instance' then ' event subscription of ' || (attributes_std ->> 'source_type') || ' type'
+        when (attributes_std ->> 'source_type') = 'db-instance' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then ' event subscription enabled for critical db cluster events'
         else ' event subscription missing critical db instance events'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -505,15 +505,15 @@ query "rds_db_instance_events_subscription" {
 query "rds_db_instance_iam_authentication_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'iam_database_authentication_enabled') is null then 'alarm'
-        when (arguments -> 'iam_database_authentication_enabled')::bool then 'ok'
+        when (attributes_std -> 'iam_database_authentication_enabled') is null then 'alarm'
+        when (attributes_std -> 'iam_database_authentication_enabled')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'iam_database_authentication_enabled') is null then ' ''iam_database_authentication_enabled'' disabled'
-        when (arguments -> 'iam_database_authentication_enabled')::bool then ' ''iam_database_authentication_enabled'' enabled'
+      address || case
+        when (attributes_std -> 'iam_database_authentication_enabled') is null then ' ''iam_database_authentication_enabled'' disabled'
+        when (attributes_std -> 'iam_database_authentication_enabled')::bool then ' ''iam_database_authentication_enabled'' enabled'
         else ' ''iam_database_authentication_enabled'' disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -528,59 +528,59 @@ query "rds_db_instance_iam_authentication_enabled" {
 query "rds_db_instance_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
-      (arguments -> 'engine')::text as engine,
+      address as resource,
+      (attributes_std -> 'engine')::text as engine,
       case
         when
-          (arguments ->> 'engine')::text like any (array ['mariadb', '%mysql'])
-          and (arguments -> 'enabled_cloudwatch_logs_exports') is not null
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["audit","error","general","slowquery"]'::jsonb
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["audit","error","general","slowquery"]'::jsonb then 'ok'
+          (attributes_std ->> 'engine')::text like any (array ['mariadb', '%mysql'])
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["audit","error","general","slowquery"]'::jsonb
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["audit","error","general","slowquery"]'::jsonb then 'ok'
         when
-          (arguments ->> 'engine')::text like any (array['%postgres%'])
-          and (arguments -> 'enabled_cloudwatch_logs_exports') is not null
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["postgresql","upgrade"]'::jsonb
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["postgresql","upgrade"]'::jsonb then 'ok'
+          (attributes_std ->> 'engine')::text like any (array['%postgres%'])
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["postgresql","upgrade"]'::jsonb
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["postgresql","upgrade"]'::jsonb then 'ok'
         when
-          (arguments ->> 'engine')::text like 'oracle%' and (arguments -> 'enabled_cloudwatch_logs_exports') is not null
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["alert","audit", "trace","listener"]'::jsonb
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["alert","audit", "trace","listener"]'::jsonb then 'ok'
+          (attributes_std ->> 'engine')::text like 'oracle%' and (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["alert","audit", "trace","listener"]'::jsonb
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["alert","audit", "trace","listener"]'::jsonb then 'ok'
         when
-          (arguments ->> 'engine')::text = 'sqlserver-ex'
-          and (arguments -> 'enabled_cloudwatch_logs_exports') is not null
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["error"]'::jsonb
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["error"]'::jsonb then 'ok'
+          (attributes_std ->> 'engine')::text = 'sqlserver-ex'
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["error"]'::jsonb
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["error"]'::jsonb then 'ok'
         when
-          (arguments ->> 'engine')::text like 'sqlserver%'
-          and (arguments -> 'enabled_cloudwatch_logs_exports')is not null
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["error","agent"]' then 'ok'
+          (attributes_std ->> 'engine')::text like 'sqlserver%'
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')is not null
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["error","agent"]' then 'ok'
         else 'alarm'
       end as status,
-      name || case
+      address || case
         when
-          (arguments ->> 'engine')::text like any (array ['mariadb', '%mysql'])
-          and (arguments -> 'enabled_cloudwatch_logs_exports') is not null
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["audit","error","general","slowquery"]'::jsonb
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["audit","error","general","slowquery"]'::jsonb then ' logging enabled'
+          (attributes_std ->> 'engine')::text like any (array ['mariadb', '%mysql'])
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["audit","error","general","slowquery"]'::jsonb
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["audit","error","general","slowquery"]'::jsonb then ' logging enabled'
         when
-          (arguments ->> 'engine')::text like any (array['%postgres%'])
-          and (arguments -> 'enabled_cloudwatch_logs_exports') is not null
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["postgresql","upgrade"]'::jsonb
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["postgresql","upgrade"]'::jsonb then ' logging enabled'
+          (attributes_std ->> 'engine')::text like any (array['%postgres%'])
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["postgresql","upgrade"]'::jsonb
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["postgresql","upgrade"]'::jsonb then ' logging enabled'
         when
-          (arguments ->> 'engine')::text like 'oracle%'
-          and (arguments -> 'enabled_cloudwatch_logs_exports') is not null
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["alert","audit", "trace","listener"]'::jsonb
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["alert","audit", "trace","listener"]'::jsonb then ' logging enabled'
+          (attributes_std ->> 'engine')::text like 'oracle%'
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["alert","audit", "trace","listener"]'::jsonb
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["alert","audit", "trace","listener"]'::jsonb then ' logging enabled'
         when
-          (arguments ->> 'engine')::text = 'sqlserver-ex'
-          and (arguments -> 'enabled_cloudwatch_logs_exports') is not null
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["error"]'::jsonb
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["error"]'::jsonb then ' logging enabled'
+          (attributes_std ->> 'engine')::text = 'sqlserver-ex'
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports') is not null
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["error"]'::jsonb
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb @> '["error"]'::jsonb then ' logging enabled'
         when
-          (arguments ->> 'engine')::text like 'sqlserver%'
-          and (arguments -> 'enabled_cloudwatch_logs_exports')is not null
-          and (arguments -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["error","agent"]' then ' logging enabled'
+          (attributes_std ->> 'engine')::text like 'sqlserver%'
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')is not null
+          and (attributes_std -> 'enabled_cloudwatch_logs_exports')::jsonb <@ '["error","agent"]' then ' logging enabled'
         else ' logging disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -595,15 +595,15 @@ query "rds_db_instance_logging_enabled" {
 query "rds_db_instance_multiple_az_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'multi_az') is null then 'alarm'
-        when (arguments -> 'multi_az')::boolean then 'ok'
+        when (attributes_std -> 'multi_az') is null then 'alarm'
+        when (attributes_std -> 'multi_az')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'multi_az') is null then ' ''multi_az'' disabled'
-        when (arguments -> 'multi_az')::boolean then ' ''multi_az'' enabled'
+      address || case
+        when (attributes_std -> 'multi_az') is null then ' ''multi_az'' disabled'
+        when (attributes_std -> 'multi_az')::boolean then ' ''multi_az'' enabled'
         else ' ''multi_az'' disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -618,15 +618,15 @@ query "rds_db_instance_multiple_az_enabled" {
 query "rds_db_instance_prohibit_public_access" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'publicly_accessible') is null then 'ok'
-        when (arguments -> 'publicly_accessible')::boolean then 'alarm'
+        when (attributes_std -> 'publicly_accessible') is null then 'ok'
+        when (attributes_std -> 'publicly_accessible')::boolean then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'publicly_accessible') is null then ' not publicly accessible'
-        when (arguments -> 'publicly_accessible')::boolean then ' publicly accessible'
+      address || case
+        when (attributes_std -> 'publicly_accessible') is null then ' not publicly accessible'
+        when (attributes_std -> 'publicly_accessible')::boolean then ' publicly accessible'
         else ' not publicly accessible'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -641,15 +641,15 @@ query "rds_db_instance_prohibit_public_access" {
 query "rds_db_parameter_group_events_subscription" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'source_type') <> 'db-parameter-group' then 'skip'
-        when (arguments ->> 'source_type') = 'db-parameter-group' and (arguments -> 'enabled')::bool and (arguments -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (arguments -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then 'ok'
+        when (attributes_std ->> 'source_type') <> 'db-parameter-group' then 'skip'
+        when (attributes_std ->> 'source_type') = 'db-parameter-group' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'source_type') <> 'db-parameter-group' then ' event subscription of ' || (arguments ->> 'source_type') || ' type'
-        when (arguments ->> 'source_type') = 'db-parameter-group' and (arguments -> 'enabled')::bool and (arguments -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (arguments -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then ' event subscription enabled for critical database parameter group events'
+      address || case
+        when (attributes_std ->> 'source_type') <> 'db-parameter-group' then ' event subscription of ' || (attributes_std ->> 'source_type') || ' type'
+        when (attributes_std ->> 'source_type') = 'db-parameter-group' and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "maintenance"]'::jsonb and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "maintenance"]'::jsonb then ' event subscription enabled for critical database parameter group events'
         else ' event subscription missing critical database parameter group events'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -664,22 +664,22 @@ query "rds_db_parameter_group_events_subscription" {
 query "rds_db_security_group_events_subscription" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'source_type') <> 'db-security-group' then 'skip'
+        when (attributes_std ->> 'source_type') <> 'db-security-group' then 'skip'
         when
-          (arguments ->> 'source_type') = 'db-security-group'
-          and (arguments -> 'enabled')::bool
-          and (arguments -> 'event_categories_list')::jsonb @> '["failure", "configuration change"]'::jsonb
-          and (arguments -> 'event_categories_list')::jsonb <@ '["failure", "configuration change"]'::jsonb then 'ok'
+          (attributes_std ->> 'source_type') = 'db-security-group'
+          and (attributes_std -> 'enabled')::bool
+          and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "configuration change"]'::jsonb
+          and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "configuration change"]'::jsonb then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'source_type') <> 'db-security-group' then ' event subscription of ' || (arguments ->> 'source_type') || ' type'
+      address || case
+        when (attributes_std ->> 'source_type') <> 'db-security-group' then ' event subscription of ' || (attributes_std ->> 'source_type') || ' type'
         when
-          (arguments ->> 'source_type') = 'db-security-group'
-          and (arguments -> 'enabled')::bool and (arguments -> 'event_categories_list')::jsonb @> '["failure", "configuration change"]'::jsonb
-          and (arguments -> 'event_categories_list')::jsonb <@ '["failure", "configuration change"]'::jsonb then ' event subscription enabled for critical database security group events'
+          (attributes_std ->> 'source_type') = 'db-security-group'
+          and (attributes_std -> 'enabled')::bool and (attributes_std -> 'event_categories_list')::jsonb @> '["failure", "configuration change"]'::jsonb
+          and (attributes_std -> 'event_categories_list')::jsonb <@ '["failure", "configuration change"]'::jsonb then ' event subscription enabled for critical database security group events'
         else ' event subscription missing critical database security group events'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -694,15 +694,15 @@ query "rds_db_security_group_events_subscription" {
 query "rds_db_instance_uses_recent_ca_certificate" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'ca_cert_identifier') in ('rds-ca-rsa2048-g1', 'rds-ca-rsa4096-g1', 'rds-ca-ecc384-g1') then 'ok'
-        when (arguments ->> 'ca_cert_identifier') is null then 'skip'
+        when (attributes_std ->> 'ca_cert_identifier') in ('rds-ca-rsa2048-g1', 'rds-ca-rsa4096-g1', 'rds-ca-ecc384-g1') then 'ok'
+        when (attributes_std ->> 'ca_cert_identifier') is null then 'skip'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'ca_cert_identifier') in ('rds-ca-rsa2048-g1', 'rds-ca-rsa4096-g1', 'rds-ca-ecc384-g1') then ' uses recent CA certificate'
-        when (arguments ->> 'ca_cert_identifier') is null then ' CA certificate not defined'
+      address || case
+        when (attributes_std ->> 'ca_cert_identifier') in ('rds-ca-rsa2048-g1', 'rds-ca-rsa4096-g1', 'rds-ca-ecc384-g1') then ' uses recent CA certificate'
+        when (attributes_std ->> 'ca_cert_identifier') is null then ' CA certificate not defined'
         else ' uses an old CA certificate'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -717,13 +717,13 @@ query "rds_db_instance_uses_recent_ca_certificate" {
 query "memorydb_snapshot_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_arn') is null then 'alarm'
+        when (attributes_std ->> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments ->> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -738,13 +738,13 @@ query "memorydb_snapshot_encrypted_with_kms_cmk" {
 query "memorydb_cluster_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_arn') is null then 'alarm'
+        when (attributes_std ->> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments ->> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_arn') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -759,13 +759,13 @@ query "memorydb_cluster_encrypted_with_kms_cmk" {
 query "memorydb_cluster_transit_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'tls_enabled') = 'false' then 'alarm'
+        when (attributes_std ->> 'tls_enabled') = 'false' then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments ->> 'tls_enabled') = 'false' then ' encryption at transit disabled'
+      address || case
+        when (attributes_std ->> 'tls_enabled') = 'false' then ' encryption at transit disabled'
         else ' encryption at transit enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -780,13 +780,13 @@ query "memorydb_cluster_transit_encryption_enabled" {
 query "rds_db_snapshot_not_publicly_accesible" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'shared_accounts') @> '["all"]' then 'alarm'
+        when (attributes_std -> 'shared_accounts') @> '["all"]' then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'shared_accounts') @> '["all"]' then ' publicly accessible'
+      address || case
+        when (attributes_std -> 'shared_accounts') @> '["all"]' then ' publicly accessible'
         else ' not publicly accessible'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -801,13 +801,13 @@ query "rds_db_snapshot_not_publicly_accesible" {
 query "rds_db_snapshot_copy_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is null then 'alarm'
+        when (attributes_std ->> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments ->> 'kms_key_id') is null then ' not encrypted with KMS CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -822,13 +822,13 @@ query "rds_db_snapshot_copy_encrypted_with_kms_cmk" {
 query "rds_db_cluster_instance_automatic_minor_version_upgrade_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'auto_minor_version_upgrade') = 'false' then 'alarm'
+        when (attributes_std ->> 'auto_minor_version_upgrade') = 'false' then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments ->> 'auto_minor_version_upgrade') = 'false' then ' auto minor version upgrade disabled'
+      address || case
+        when (attributes_std ->> 'auto_minor_version_upgrade') = 'false' then ' auto minor version upgrade disabled'
         else ' auto minor version upgrade enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -843,13 +843,13 @@ query "rds_db_cluster_instance_automatic_minor_version_upgrade_enabled" {
 query "rds_db_cluster_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'storage_encrypted') = 'true' or (arguments ->> 'engine_mode') = 'serverless' then 'ok'
+        when (attributes_std ->> 'storage_encrypted') = 'true' or (attributes_std ->> 'engine_mode') = 'serverless' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'storage_encrypted') = 'true' or (arguments ->> 'engine_mode') = 'serverless' then ' encryption enabled'
+      address || case
+        when (attributes_std ->> 'storage_encrypted') = 'true' or (attributes_std ->> 'engine_mode') = 'serverless' then ' encryption enabled'
         else ' encryption disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -864,15 +864,15 @@ query "rds_db_cluster_encryption_enabled" {
 query "rds_mysql_db_cluster_audit_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'engine')::text not like '%mysql' then 'skip'
-        when (arguments ->> 'engine')::text like '%mysql' and (arguments -> 'enabled_cloudwatch_logs_exports') @> '["audit"]' then 'ok'
+        when (attributes_std ->> 'engine')::text not like '%mysql' then 'skip'
+        when (attributes_std ->> 'engine')::text like '%mysql' and (attributes_std -> 'enabled_cloudwatch_logs_exports') @> '["audit"]' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'engine')::text not like '%mysql' then ' not a MySQL cluster'
-        when (arguments ->> 'engine')::text like '%mysql' and (arguments -> 'enabled_cloudwatch_logs_exports') @> '["audit"]' then ' audit logging enabled'
+      address || case
+        when (attributes_std ->> 'engine')::text not like '%mysql' then ' not a MySQL cluster'
+        when (attributes_std ->> 'engine')::text like '%mysql' and (attributes_std -> 'enabled_cloudwatch_logs_exports') @> '["audit"]' then ' audit logging enabled'
         else ' audit logging disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -887,17 +887,17 @@ query "rds_mysql_db_cluster_audit_logging_enabled" {
 query "rds_global_cluster_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'storage_encrypted')::boolean then 'ok'
-        when (arguments ->> 'source_db_cluster_identifier') is null then 'info'
-        when (arguments ->> 'storage_encrypted')::boolean and (arguments ->> 'source_db_cluster_identifier') is not null then 'ok'
+        when (attributes_std ->> 'storage_encrypted')::boolean then 'ok'
+        when (attributes_std ->> 'source_db_cluster_identifier') is null then 'info'
+        when (attributes_std ->> 'storage_encrypted')::boolean and (attributes_std ->> 'source_db_cluster_identifier') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'storage_encrypted')::boolean then ' enccryption enabled'
-        when (arguments ->> 'source_db_cluster_identifier') is null then ' DB cluster identifier is not provided of the primary global cluster creation'
-        when (arguments ->> 'storage_encrypted')::boolean and (arguments ->> 'source_db_cluster_identifier') is not null then ' enccryption enabled'
+      address || case
+        when (attributes_std ->> 'storage_encrypted')::boolean then ' enccryption enabled'
+        when (attributes_std ->> 'source_db_cluster_identifier') is null then ' DB cluster identifier is not provided of the primary global cluster creation'
+        when (attributes_std ->> 'storage_encrypted')::boolean and (attributes_std ->> 'source_db_cluster_identifier') is not null then ' enccryption enabled'
         else ' enccryption disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/redshift.sp
+++ b/query/redshift.sp
@@ -1,15 +1,15 @@
 query "redshift_cluster_automatic_snapshots_min_7_days" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'automated_snapshot_retention_period') is null then 'ok'
-        when (arguments -> 'automated_snapshot_retention_period')::integer > 7 then 'ok'
+        when (attributes_std -> 'automated_snapshot_retention_period') is null then 'ok'
+        when (attributes_std -> 'automated_snapshot_retention_period')::integer > 7 then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'automated_snapshot_retention_period') is null then ' ''automated_snapshot_retention_period'' set to 1 day by default'
-        when (arguments -> 'automated_snapshot_retention_period')::integer > 7 then ' ''automated_snapshot_retention_period'' set to ' || (arguments ->> 'automated_snapshot_retention_period')::integer || ' day(s)'
+      address || case
+        when (attributes_std -> 'automated_snapshot_retention_period') is null then ' ''automated_snapshot_retention_period'' set to 1 day by default'
+        when (attributes_std -> 'automated_snapshot_retention_period')::integer > 7 then ' ''automated_snapshot_retention_period'' set to ' || (attributes_std ->> 'automated_snapshot_retention_period')::integer || ' day(s)'
         else ' ''automated_snapshot_retention_period'' set to 0 days'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -24,15 +24,15 @@ query "redshift_cluster_automatic_snapshots_min_7_days" {
 query "redshift_cluster_automatic_upgrade_major_versions_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'allow_version_upgrade') is null then 'ok'
-        when (arguments -> 'allow_version_upgrade')::bool then 'ok'
+        when (attributes_std -> 'allow_version_upgrade') is null then 'ok'
+        when (attributes_std -> 'allow_version_upgrade')::bool then 'ok'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'allow_version_upgrade') is null then ' ''allow_version_upgrade'' set to true by default'
-        when (arguments -> 'allow_version_upgrade')::bool then ' ''allow_version_upgrade'' set to true'
+      address || case
+        when (attributes_std -> 'allow_version_upgrade') is null then ' ''allow_version_upgrade'' set to true by default'
+        when (attributes_std -> 'allow_version_upgrade')::bool then ' ''allow_version_upgrade'' set to true'
         else ' ''allow_version_upgrade'' set to false'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -47,13 +47,13 @@ query "redshift_cluster_automatic_upgrade_major_versions_enabled" {
 query "redshift_cluster_deployed_in_ec2_classic_mode" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'cluster_subnet_group_name') is not null then 'ok'
+        when (attributes_std -> 'cluster_subnet_group_name') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'cluster_subnet_group_name') is not null then ' deployed inside VPC'
+      address || case
+        when (attributes_std -> 'cluster_subnet_group_name') is not null then ' deployed inside VPC'
         else ' not deployed inside VPC'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -68,17 +68,17 @@ query "redshift_cluster_deployed_in_ec2_classic_mode" {
 query "redshift_cluster_encryption_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encrypted') is null then 'alarm'
-        when (arguments -> 'logging') is null then 'alarm'
-        when (arguments -> 'logging' ->> 'enabled')::boolean then 'ok'
+        when (attributes_std -> 'encrypted') is null then 'alarm'
+        when (attributes_std -> 'logging') is null then 'alarm'
+        when (attributes_std -> 'logging' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'encrypted') is null then ' not encrypted'
-        when (arguments -> 'logging') is null then ' audit logging disabled'
-        when (arguments -> 'logging' ->> 'enabled')::boolean then ' audit logging enabled'
+      address || case
+        when (attributes_std -> 'encrypted') is null then ' not encrypted'
+        when (attributes_std -> 'logging') is null then ' audit logging disabled'
+        when (attributes_std -> 'logging' ->> 'enabled')::boolean then ' audit logging enabled'
         else ' audit logging disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -93,15 +93,15 @@ query "redshift_cluster_encryption_logging_enabled" {
 query "redshift_cluster_enhanced_vpc_routing_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'enhanced_vpc_routing') is null then 'alarm'
-        when (arguments -> 'enhanced_vpc_routing')::bool then 'ok'
+        when (attributes_std -> 'enhanced_vpc_routing') is null then 'alarm'
+        when (attributes_std -> 'enhanced_vpc_routing')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'enhanced_vpc_routing') is null then ' ''enhanced_vpc_routing'' set to false by default'
-        when (arguments -> 'enhanced_vpc_routing')::bool then ' ''enhanced_vpc_routing'' set to true'
+      address || case
+        when (attributes_std -> 'enhanced_vpc_routing') is null then ' ''enhanced_vpc_routing'' set to false by default'
+        when (attributes_std -> 'enhanced_vpc_routing')::bool then ' ''enhanced_vpc_routing'' set to true'
         else ' ''allow_version_upgrade'' set to false'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -116,13 +116,13 @@ query "redshift_cluster_enhanced_vpc_routing_enabled" {
 query "redshift_cluster_kms_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'encrypted') is not null and (arguments -> 'kms_key_id') is not null then 'ok'
+        when (attributes_std -> 'encrypted') is not null and (attributes_std -> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'encrypted') is not null and (arguments -> 'kms_key_id') is not null then ' encrypted with KMS'
+      address || case
+        when (attributes_std -> 'encrypted') is not null and (attributes_std -> 'kms_key_id') is not null then ' encrypted with KMS'
         else ' not encrypted with KMS'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -137,15 +137,15 @@ query "redshift_cluster_kms_enabled" {
 query "redshift_cluster_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logging') is null then 'alarm'
-        when (arguments -> 'logging' ->> 'enabled')::boolean then 'ok'
+        when (attributes_std -> 'logging') is null then 'alarm'
+        when (attributes_std -> 'logging' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'logging') is null then ' audit logging disabled'
-        when (arguments -> 'logging' ->> 'enabled')::boolean then ' audit logging enabled'
+      address || case
+        when (attributes_std -> 'logging') is null then ' audit logging disabled'
+        when (attributes_std -> 'logging' ->> 'enabled')::boolean then ' audit logging enabled'
         else ' audit logging disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -160,17 +160,17 @@ query "redshift_cluster_logging_enabled" {
 query "redshift_cluster_maintenance_settings_check" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'allow_version_upgrade') is null and (arguments -> 'automated_snapshot_retention_period') is null then 'alarm'
-        when (arguments -> 'allow_version_upgrade') is null and (arguments -> 'automated_snapshot_retention_period')::integer >= 7 then 'ok'
-        when (arguments -> 'allow_version_upgrade')::bool and (arguments -> 'automated_snapshot_retention_period')::integer >= 7 then 'ok'
+        when (attributes_std -> 'allow_version_upgrade') is null and (attributes_std -> 'automated_snapshot_retention_period') is null then 'alarm'
+        when (attributes_std -> 'allow_version_upgrade') is null and (attributes_std -> 'automated_snapshot_retention_period')::integer >= 7 then 'ok'
+        when (attributes_std -> 'allow_version_upgrade')::bool and (attributes_std -> 'automated_snapshot_retention_period')::integer >= 7 then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'allow_version_upgrade') is null and (arguments -> 'automated_snapshot_retention_period') is null then ' does not have the required maintenance settings'
-        when (arguments -> 'allow_version_upgrade') is null and (arguments -> 'automated_snapshot_retention_period')::integer >= 7 then ' has the required maintenance settings'
-        when (arguments -> 'allow_version_upgrade')::bool and (arguments -> 'automated_snapshot_retention_period')::integer >= 7 then ' has the required maintenance settings'
+      address || case
+        when (attributes_std -> 'allow_version_upgrade') is null and (attributes_std -> 'automated_snapshot_retention_period') is null then ' does not have the required maintenance settings'
+        when (attributes_std -> 'allow_version_upgrade') is null and (attributes_std -> 'automated_snapshot_retention_period')::integer >= 7 then ' has the required maintenance settings'
+        when (attributes_std -> 'allow_version_upgrade')::bool and (attributes_std -> 'automated_snapshot_retention_period')::integer >= 7 then ' has the required maintenance settings'
         else ' does not have the required maintenance settings'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -185,15 +185,15 @@ query "redshift_cluster_maintenance_settings_check" {
 query "redshift_cluster_prohibit_public_access" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'publicly_accessible') is null then 'alarm'
-        when (arguments -> 'publicly_accessible')::bool then 'alarm'
+        when (attributes_std -> 'publicly_accessible') is null then 'alarm'
+        when (attributes_std -> 'publicly_accessible')::bool then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'publicly_accessible') is null then ' publicly accessible'
-        when (arguments -> 'publicly_accessible')::bool then ' publicly accessible'
+      address || case
+        when (attributes_std -> 'publicly_accessible') is null then ' publicly accessible'
+        when (attributes_std -> 'publicly_accessible')::bool then ' publicly accessible'
         else ' not publicly accessible'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -208,13 +208,13 @@ query "redshift_cluster_prohibit_public_access" {
 query "redshift_cluster_no_default_database_name" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'database_name') is not null then 'ok'
+        when (attributes_std ->> 'database_name') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'database_name') is not null then ' database name defined'
+      address || case
+        when (attributes_std ->> 'database_name') is not null then ' database name defined'
         else ' no database name defined'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -229,15 +229,15 @@ query "redshift_cluster_no_default_database_name" {
 query "redshift_cluster_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'encrypted') is null then 'alarm'
-        when (arguments ->> 'encrypted')::bool then 'ok'
+        when (attributes_std ->> 'encrypted') is null then 'alarm'
+        when (attributes_std ->> 'encrypted')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'encrypted') is null then ' encryption disabled'
-        when (arguments ->> 'encrypted')::bool then ' encryption enabled'
+      address || case
+        when (attributes_std ->> 'encrypted') is null then ' encryption disabled'
+        when (attributes_std ->> 'encrypted')::bool then ' encryption enabled'
         else ' encryption disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -252,13 +252,13 @@ query "redshift_cluster_encryption_enabled" {
 query "redshift_serverless_namespace_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is not null then 'ok'
+        when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -273,13 +273,13 @@ query "redshift_serverless_namespace_encrypted_with_kms_cmk" {
 query "redshift_snapshot_copy_grant_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is not null then 'ok'
+        when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/redshift.sp
+++ b/query/redshift.sp
@@ -7,7 +7,7 @@ query "redshift_cluster_automatic_snapshots_min_7_days" {
         when (attributes_std -> 'automated_snapshot_retention_period')::integer > 7 then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'automated_snapshot_retention_period') is null then ' ''automated_snapshot_retention_period'' set to 1 day by default'
         when (attributes_std -> 'automated_snapshot_retention_period')::integer > 7 then ' ''automated_snapshot_retention_period'' set to ' || (attributes_std ->> 'automated_snapshot_retention_period')::integer || ' day(s)'
         else ' ''automated_snapshot_retention_period'' set to 0 days'
@@ -30,7 +30,7 @@ query "redshift_cluster_automatic_upgrade_major_versions_enabled" {
         when (attributes_std -> 'allow_version_upgrade')::bool then 'ok'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'allow_version_upgrade') is null then ' ''allow_version_upgrade'' set to true by default'
         when (attributes_std -> 'allow_version_upgrade')::bool then ' ''allow_version_upgrade'' set to true'
         else ' ''allow_version_upgrade'' set to false'
@@ -52,7 +52,7 @@ query "redshift_cluster_deployed_in_ec2_classic_mode" {
         when (attributes_std -> 'cluster_subnet_group_name') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'cluster_subnet_group_name') is not null then ' deployed inside VPC'
         else ' not deployed inside VPC'
       end || '.' as reason
@@ -75,7 +75,7 @@ query "redshift_cluster_encryption_logging_enabled" {
         when (attributes_std -> 'logging' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encrypted') is null then ' not encrypted'
         when (attributes_std -> 'logging') is null then ' audit logging disabled'
         when (attributes_std -> 'logging' ->> 'enabled')::boolean then ' audit logging enabled'
@@ -99,7 +99,7 @@ query "redshift_cluster_enhanced_vpc_routing_enabled" {
         when (attributes_std -> 'enhanced_vpc_routing')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'enhanced_vpc_routing') is null then ' ''enhanced_vpc_routing'' set to false by default'
         when (attributes_std -> 'enhanced_vpc_routing')::bool then ' ''enhanced_vpc_routing'' set to true'
         else ' ''allow_version_upgrade'' set to false'
@@ -121,7 +121,7 @@ query "redshift_cluster_kms_enabled" {
         when (attributes_std -> 'encrypted') is not null and (attributes_std -> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encrypted') is not null and (attributes_std -> 'kms_key_id') is not null then ' encrypted with KMS'
         else ' not encrypted with KMS'
       end || '.' as reason
@@ -143,7 +143,7 @@ query "redshift_cluster_logging_enabled" {
         when (attributes_std -> 'logging' ->> 'enabled')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'logging') is null then ' audit logging disabled'
         when (attributes_std -> 'logging' ->> 'enabled')::boolean then ' audit logging enabled'
         else ' audit logging disabled'
@@ -167,7 +167,7 @@ query "redshift_cluster_maintenance_settings_check" {
         when (attributes_std -> 'allow_version_upgrade')::bool and (attributes_std -> 'automated_snapshot_retention_period')::integer >= 7 then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'allow_version_upgrade') is null and (attributes_std -> 'automated_snapshot_retention_period') is null then ' does not have the required maintenance settings'
         when (attributes_std -> 'allow_version_upgrade') is null and (attributes_std -> 'automated_snapshot_retention_period')::integer >= 7 then ' has the required maintenance settings'
         when (attributes_std -> 'allow_version_upgrade')::bool and (attributes_std -> 'automated_snapshot_retention_period')::integer >= 7 then ' has the required maintenance settings'
@@ -191,7 +191,7 @@ query "redshift_cluster_prohibit_public_access" {
         when (attributes_std -> 'publicly_accessible')::bool then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'publicly_accessible') is null then ' publicly accessible'
         when (attributes_std -> 'publicly_accessible')::bool then ' publicly accessible'
         else ' not publicly accessible'
@@ -213,7 +213,7 @@ query "redshift_cluster_no_default_database_name" {
         when (attributes_std ->> 'database_name') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'database_name') is not null then ' database name defined'
         else ' no database name defined'
       end || '.' as reason
@@ -235,7 +235,7 @@ query "redshift_cluster_encryption_enabled" {
         when (attributes_std ->> 'encrypted')::bool then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'encrypted') is null then ' encryption disabled'
         when (attributes_std ->> 'encrypted')::bool then ' encryption enabled'
         else ' encryption disabled'
@@ -257,7 +257,7 @@ query "redshift_serverless_namespace_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' as reason
@@ -278,7 +278,7 @@ query "redshift_snapshot_copy_grant_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with KMS CMK'
         else ' not encrypted with KMS CMK'
       end || '.' as reason

--- a/query/s3.sp
+++ b/query/s3.sp
@@ -1,14 +1,14 @@
 query "s3_bucket_cross_region_replication_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'cors_rule')::jsonb ?& array['allowed_methods', 'allowed_origins'] then 'ok'
+        when (attributes_std -> 'cors_rule')::jsonb ?& array['allowed_methods', 'allowed_origins'] then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'cors_rule') is null then ' ''cors_rule'' is not defined'
-        when (arguments -> 'cors_rule')::jsonb ?& array['allowed_methods', 'allowed_origins'] then ' enabled with cross-region replication'
+      address || case
+        when (attributes_std -> 'cors_rule') is null then ' ''cors_rule'' is not defined'
+        when (attributes_std -> 'cors_rule')::jsonb ?& array['allowed_methods', 'allowed_origins'] then ' enabled with cross-region replication'
         else ' not enabled with cross-region replication'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -23,15 +23,15 @@ query "s3_bucket_cross_region_replication_enabled" {
 query "s3_bucket_default_encryption_enabled_kms" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when coalesce(trim(arguments -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm'), '') <> 'aws:kms'
+        when coalesce(trim(attributes_std -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm'), '') <> 'aws:kms'
         then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when coalesce(trim(arguments -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm'), '') = '' then ' ''sse_algorithm'' is not defined'
-        when trim(arguments -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm') = 'aws:kms' then ' default encryption with KMS enabled'
+      address || case
+        when coalesce(trim(attributes_std -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm'), '') = '' then ' ''sse_algorithm'' is not defined'
+        when trim(attributes_std -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm') = 'aws:kms' then ' default encryption with KMS enabled'
         else ' default encryption with KMS disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -46,15 +46,15 @@ query "s3_bucket_default_encryption_enabled_kms" {
 query "s3_bucket_default_encryption_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when coalesce(trim(arguments -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm'), '') = '' then 'alarm'
-        when coalesce(trim(arguments -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm'), '') not in ('aws:kms', 'AES256') then 'alarm'
+        when coalesce(trim(attributes_std -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm'), '') = '' then 'alarm'
+        when coalesce(trim(attributes_std -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm'), '') not in ('aws:kms', 'AES256') then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when coalesce(trim(arguments -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm'), '') = '' then ' ''sse_algorithm'' is not defined'
-        when trim(arguments -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm') in ('aws:kms', 'AES256') then ' default encryption enabled'
+      address || case
+        when coalesce(trim(attributes_std -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm'), '') = '' then ' ''sse_algorithm'' is not defined'
+        when trim(attributes_std -> 'server_side_encryption_configuration' -> 'rule' -> 'apply_server_side_encryption_by_default' ->> 'sse_algorithm') in ('aws:kms', 'AES256') then ' default encryption enabled'
         else ' default encryption disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -69,15 +69,15 @@ query "s3_bucket_default_encryption_enabled" {
 query "s3_bucket_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logging' -> 'target_bucket') is null then 'alarm'
-        when coalesce(trim(arguments -> 'logging' ->> 'target_bucket'), '') = '' then 'alarm'
+        when (attributes_std -> 'logging' -> 'target_bucket') is null then 'alarm'
+        when coalesce(trim(attributes_std -> 'logging' ->> 'target_bucket'), '') = '' then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'logging' -> 'target_bucket') is null then ' ''target_bucket'' is not defined'
-        when coalesce(trim(arguments -> 'logging' ->> 'target_bucket'), '') = '' then ' logging disabled'
+      address || case
+        when (attributes_std -> 'logging' -> 'target_bucket') is null then ' ''target_bucket'' is not defined'
+        when coalesce(trim(attributes_std -> 'logging' ->> 'target_bucket'), '') = '' then ' logging disabled'
         else ' logging enabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -92,13 +92,13 @@ query "s3_bucket_logging_enabled" {
 query "s3_bucket_mfa_delete_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when coalesce(trim(lower(arguments -> 'versioning' ->> 'mfa_delete')), '') in ('true', 'false') and (arguments -> 'versioning' ->> 'mfa_delete')::bool then 'ok'
+        when coalesce(trim(lower(attributes_std -> 'versioning' ->> 'mfa_delete')), '') in ('true', 'false') and (attributes_std -> 'versioning' ->> 'mfa_delete')::bool then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'versioning' ->> 'mfa_delete')::bool then ' MFA delete enabled'
+      address || case
+        when (attributes_std -> 'versioning' ->> 'mfa_delete')::bool then ' MFA delete enabled'
         else ' MFA delete disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -113,14 +113,14 @@ query "s3_bucket_mfa_delete_enabled" {
 query "s3_bucket_object_lock_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when coalesce(trim(arguments -> 'object_lock_configuration' ->> 'object_lock_enabled'), '') = 'Enabled' then 'ok'
+        when coalesce(trim(attributes_std -> 'object_lock_configuration' ->> 'object_lock_enabled'), '') = 'Enabled' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'object_lock_configuration' -> 'object_lock_enabled') is null then ' ''object_lock_enabled'' is not defined'
-        when (arguments -> 'object_lock_configuration' ->> 'object_lock_enabled') = 'Enabled' then ' object lock enabled'
+      address || case
+        when (attributes_std -> 'object_lock_configuration' -> 'object_lock_enabled') is null then ' ''object_lock_enabled'' is not defined'
+        when (attributes_std -> 'object_lock_configuration' ->> 'object_lock_enabled') = 'Enabled' then ' object lock enabled'
         else ' object lock not enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -135,40 +135,40 @@ query "s3_bucket_object_lock_enabled" {
 query "s3_bucket_public_access_blocked" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-          (arguments ->> 'block_public_acls')::boolean
-          and (arguments ->> 'block_public_policy')::boolean
-          and (arguments ->> 'ignore_public_acls')::boolean
-          and (arguments ->> 'restrict_public_buckets')::boolean
+          (attributes_std ->> 'block_public_acls')::boolean
+          and (attributes_std ->> 'block_public_policy')::boolean
+          and (attributes_std ->> 'ignore_public_acls')::boolean
+          and (attributes_std ->> 'restrict_public_buckets')::boolean
         then 'ok'
         else 'alarm'
       end as status,
       case
         when
-          arguments -> 'block_public_acls' is null
-          or arguments -> 'block_public_policy' is null
-          or arguments -> 'ignore_public_acls' is null
-          or arguments -> 'restrict_public_buckets' is null
+          attributes_std -> 'block_public_acls' is null
+          or attributes_std -> 'block_public_policy' is null
+          or attributes_std -> 'ignore_public_acls' is null
+          or attributes_std -> 'restrict_public_buckets' is null
         then concat_ws(', ',
-            case when arguments -> 'block_public_acls' is null then 'block_public_acls' end,
-            case when arguments -> 'block_public_policy' is null then 'block_public_policy' end,
-            case when arguments -> 'ignore_public_acls' is null then 'ignore_public_acls' end,
-            case when arguments -> 'restrict_public_buckets' is null then 'restrict_public_buckets' end
+            case when attributes_std -> 'block_public_acls' is null then 'block_public_acls' end,
+            case when attributes_std -> 'block_public_policy' is null then 'block_public_policy' end,
+            case when attributes_std -> 'ignore_public_acls' is null then 'ignore_public_acls' end,
+            case when attributes_std -> 'restrict_public_buckets' is null then 'restrict_public_buckets' end
           ) || ' not defined'
         when
-          (arguments ->> 'block_public_acls')::boolean
-          and (arguments ->> 'block_public_policy')::boolean
-          and (arguments ->> 'ignore_public_acls')::boolean
-          and (arguments ->> 'restrict_public_buckets')::boolean
+          (attributes_std ->> 'block_public_acls')::boolean
+          and (attributes_std ->> 'block_public_policy')::boolean
+          and (attributes_std ->> 'ignore_public_acls')::boolean
+          and (attributes_std ->> 'restrict_public_buckets')::boolean
         then 'Public access blocks enabled'
         else 'Public access not enabled for: ' ||
           concat_ws(', ',
-        case when not ((arguments ->> 'block_public_acls')::boolean) then 'block_public_acls' end,
-        case when not ((arguments ->> 'block_public_policy')::boolean) then 'block_public_policy' end,
-        case when not ((arguments ->> 'ignore_public_acls')::boolean ) then 'ignore_public_acls' end,
-        case when not ((arguments ->> 'restrict_public_buckets')::boolean) then 'restrict_public_buckets' end
+        case when not ((attributes_std ->> 'block_public_acls')::boolean) then 'block_public_acls' end,
+        case when not ((attributes_std ->> 'block_public_policy')::boolean) then 'block_public_policy' end,
+        case when not ((attributes_std ->> 'ignore_public_acls')::boolean ) then 'ignore_public_acls' end,
+        case when not ((attributes_std ->> 'restrict_public_buckets')::boolean) then 'restrict_public_buckets' end
       )
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -182,15 +182,15 @@ query "s3_bucket_public_access_blocked" {
 query "s3_bucket_versioning_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when coalesce(trim(lower(arguments -> 'versioning' ->> 'enabled')), '') in ('true', 'false') and (arguments -> 'versioning' -> 'enabled')::bool
+        when coalesce(trim(lower(attributes_std -> 'versioning' ->> 'enabled')), '') in ('true', 'false') and (attributes_std -> 'versioning' -> 'enabled')::bool
         then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when coalesce(trim(lower(arguments -> 'versioning' ->> 'enabled')), '') not in ('true', 'false') then ' versioning disabled'
-        when (arguments -> 'versioning' ->> 'enabled')::bool then ' versioning enabled'
+      address || case
+        when coalesce(trim(lower(attributes_std -> 'versioning' ->> 'enabled')), '') not in ('true', 'false') then ' versioning disabled'
+        when (attributes_std -> 'versioning' ->> 'enabled')::bool then ' versioning enabled'
         else ' versioning disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -205,40 +205,40 @@ query "s3_bucket_versioning_enabled" {
 query "s3_public_access_block_account" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
         when
-          (arguments ->> 'block_public_acls')::boolean
-          and (arguments ->> 'block_public_policy')::boolean
-          and (arguments ->> 'ignore_public_acls')::boolean
-          and (arguments ->> 'restrict_public_buckets')::boolean
+          (attributes_std ->> 'block_public_acls')::boolean
+          and (attributes_std ->> 'block_public_policy')::boolean
+          and (attributes_std ->> 'ignore_public_acls')::boolean
+          and (attributes_std ->> 'restrict_public_buckets')::boolean
         then 'ok'
         else 'alarm'
       end as status,
       case
         when
-          arguments -> 'block_public_acls' is null
-          or arguments -> 'block_public_policy' is null
-          or arguments -> 'ignore_public_acls' is null
-          or arguments -> 'restrict_public_buckets' is null
+          attributes_std -> 'block_public_acls' is null
+          or attributes_std -> 'block_public_policy' is null
+          or attributes_std -> 'ignore_public_acls' is null
+          or attributes_std -> 'restrict_public_buckets' is null
         then concat_ws(', ',
-            case when arguments -> 'block_public_acls' is null then 'block_public_acls' end,
-            case when arguments -> 'block_public_policy' is null then 'block_public_policy' end,
-            case when arguments -> 'ignore_public_acls' is null then 'ignore_public_acls' end,
-            case when arguments -> 'restrict_public_buckets' is null then 'restrict_public_buckets' end
+            case when attributes_std -> 'block_public_acls' is null then 'block_public_acls' end,
+            case when attributes_std -> 'block_public_policy' is null then 'block_public_policy' end,
+            case when attributes_std -> 'ignore_public_acls' is null then 'ignore_public_acls' end,
+            case when attributes_std -> 'restrict_public_buckets' is null then 'restrict_public_buckets' end
           ) || ' not defined'
         when
-          (arguments ->> 'block_public_acls')::boolean
-          and (arguments ->> 'block_public_policy')::boolean
-          and (arguments ->> 'ignore_public_acls')::boolean
-          and (arguments ->> 'restrict_public_buckets')::boolean
+          (attributes_std ->> 'block_public_acls')::boolean
+          and (attributes_std ->> 'block_public_policy')::boolean
+          and (attributes_std ->> 'ignore_public_acls')::boolean
+          and (attributes_std ->> 'restrict_public_buckets')::boolean
         then 'Account level public access blocks enabled'
         else 'Account level public access not enabled for: ' ||
           concat_ws(', ',
-            case when not ((arguments ->> 'block_public_acls')::boolean) then 'block_public_acls' end,
-            case when not ((arguments ->> 'block_public_policy')::boolean) then 'block_public_policy' end,
-            case when not ((arguments ->> 'ignore_public_acls')::boolean ) then 'ignore_public_acls' end,
-            case when not ((arguments ->> 'restrict_public_buckets')::boolean) then 'restrict_public_buckets' end
+            case when not ((attributes_std ->> 'block_public_acls')::boolean) then 'block_public_acls' end,
+            case when not ((attributes_std ->> 'block_public_policy')::boolean) then 'block_public_policy' end,
+            case when not ((attributes_std ->> 'ignore_public_acls')::boolean ) then 'ignore_public_acls' end,
+            case when not ((attributes_std ->> 'restrict_public_buckets')::boolean) then 'restrict_public_buckets' end
           )
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -252,14 +252,14 @@ query "s3_public_access_block_account" {
 query "s3_bucket_block_public_policy_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'block_public_policy')::boolean then 'ok'
+        when (attributes_std ->> 'block_public_policy')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'block_public_policy') is null then ' block_public_acls not defined'
-        when (arguments ->> 'block_public_policy')::boolean then ' block_public_policy enabled'
+      address || case
+        when (attributes_std -> 'block_public_policy') is null then ' block_public_acls not defined'
+        when (attributes_std ->> 'block_public_policy')::boolean then ' block_public_policy enabled'
         else ' block_public_policy disabled'
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -273,13 +273,13 @@ query "s3_bucket_block_public_policy_enabled" {
 query "s3_bucket_object_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when arguments -> 'kms_key_id' is not null then 'ok'
+        when attributes_std -> 'kms_key_id' is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when arguments -> 'kms_key_id' is not null then ' encrypted with KMS'
+      address || case
+        when attributes_std -> 'kms_key_id' is not null then ' encrypted with KMS'
         else ' not encrypted with KMS'
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -293,14 +293,14 @@ query "s3_bucket_object_encrypted_with_kms_cmk" {
 query "s3_bucket_ignore_public_acls_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'ignore_public_acls')::boolean then 'ok'
+        when (attributes_std ->> 'ignore_public_acls')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'ignore_public_acls') is null then ' ignore_public_acls not defined'
-        when (arguments ->> 'ignore_public_acls')::boolean then ' ignore_public_acls enabled'
+      address || case
+        when (attributes_std -> 'ignore_public_acls') is null then ' ignore_public_acls not defined'
+        when (attributes_std ->> 'ignore_public_acls')::boolean then ' ignore_public_acls enabled'
         else ' ignore_public_acls disabled'
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -314,13 +314,13 @@ query "s3_bucket_ignore_public_acls_enabled" {
 query "s3_bucket_object_copy_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when arguments -> 'kms_key_id' is not null then 'ok'
+        when attributes_std -> 'kms_key_id' is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when arguments -> 'kms_key_id' is not null then ' encrypted with KMS'
+      address || case
+        when attributes_std -> 'kms_key_id' is not null then ' encrypted with KMS'
         else ' not encrypted with KMS'
       end || '.' as reason
       ${local.common_dimensions_sql}
@@ -335,10 +335,10 @@ query "s3_bucket_abort_incomplete_multipart_upload_enabled" {
   sql = <<-EOQ
     with lifecycle_configuration_with_abort_incomplete_multipart_upload as (
       select
-        concat(type || ' ' || name) as name
+        concat(address) as name
       from
         terraform_resource,
-        jsonb_array_elements(arguments -> 'rule') as r
+        jsonb_array_elements(attributes_std -> 'rule') as r
       where
         r ->> 'id' = 'AbortIncompleteMultipartUploadRule'
         and r ->> 'status' = 'Enabled'
@@ -350,7 +350,7 @@ query "s3_bucket_abort_incomplete_multipart_upload_enabled" {
         when u.name is not null then 'ok'
         else 'alarm'
       end as status,
-      r.name || case
+      r.address || case
         when u.name is not null then ' has abort incomplete multipart upload enabled'
         else ' has abort incomplete multipart upload disabled'
       end || '.' as reason

--- a/query/sagemaker.sp
+++ b/query/sagemaker.sp
@@ -6,7 +6,7 @@ query "sagemaker_endpoint_configuration_encryption_at_rest_enabled" {
         when (attributes_std -> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_arn') is null then ' encryption at rest not enabled'
         else ' encryption at rest enabled'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "sagemaker_notebook_instance_direct_internet_access_disabled" {
         when (attributes_std -> 'direct_internet_access') is null or (attributes_std ->> 'direct_internet_access') = 'Disabled' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when trim(attributes_std ->> 'direct_internet_access') = '' then ' ''direct_internet_access'' is not defined'
         when (attributes_std -> 'direct_internet_access') is null or (attributes_std ->> 'direct_internet_access') = 'Disabled' then ' direct internet access disabled'
         else ' direct internet access enabled'
@@ -49,7 +49,7 @@ query "sagemaker_notebook_instance_encryption_at_rest_enabled" {
         when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_key_id') is null then ' encryption at rest disabled'
         else ' encryption at rest enabled'
       end || '.' reason
@@ -70,7 +70,7 @@ query "sagemaker_notebook_instance_in_vpc" {
         when (attributes_std -> 'subnet_id') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'subnet_id') is not null then ' in VPC'
         else ' not in VPC'
       end || '.' reason
@@ -91,7 +91,7 @@ query "sagemaker_notebook_instance_root_access_disabled" {
         when (attributes_std ->> 'root_access') = 'Disabled' then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'root_access') = 'Disabled' then ' root access disabled'
         else ' root access enabled'
       end || '.' reason
@@ -112,7 +112,7 @@ query "sagemaker_domain_encrypted_with_kms_cmk" {
         when attributes_std -> 'kms_key_id' is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when attributes_std -> 'kms_key_id' is not null then ' encrypted with KMS'
         else ' not encrypted with KMS'
       end || '.' as reason

--- a/query/sagemaker.sp
+++ b/query/sagemaker.sp
@@ -1,13 +1,13 @@
 query "sagemaker_endpoint_configuration_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_arn') is null then 'alarm'
+        when (attributes_std -> 'kms_key_arn') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kms_key_arn') is null then ' encryption at rest not enabled'
+      address || case
+        when (attributes_std -> 'kms_key_arn') is null then ' encryption at rest not enabled'
         else ' encryption at rest enabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,14 +22,14 @@ query "sagemaker_endpoint_configuration_encryption_at_rest_enabled" {
 query "sagemaker_notebook_instance_direct_internet_access_disabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'direct_internet_access') is null or (arguments ->> 'direct_internet_access') = 'Disabled' then 'ok'
+        when (attributes_std -> 'direct_internet_access') is null or (attributes_std ->> 'direct_internet_access') = 'Disabled' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when trim(arguments ->> 'direct_internet_access') = '' then ' ''direct_internet_access'' is not defined'
-        when (arguments -> 'direct_internet_access') is null or (arguments ->> 'direct_internet_access') = 'Disabled' then ' direct internet access disabled'
+      address || case
+        when trim(attributes_std ->> 'direct_internet_access') = '' then ' ''direct_internet_access'' is not defined'
+        when (attributes_std -> 'direct_internet_access') is null or (attributes_std ->> 'direct_internet_access') = 'Disabled' then ' direct internet access disabled'
         else ' direct internet access enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -44,13 +44,13 @@ query "sagemaker_notebook_instance_direct_internet_access_disabled" {
 query "sagemaker_notebook_instance_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_key_id') is null then 'alarm'
+        when (attributes_std -> 'kms_key_id') is null then 'alarm'
         else 'ok'
       end status,
-      name || case
-        when (arguments -> 'kms_key_id') is null then ' encryption at rest disabled'
+      address || case
+        when (attributes_std -> 'kms_key_id') is null then ' encryption at rest disabled'
         else ' encryption at rest enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -65,13 +65,13 @@ query "sagemaker_notebook_instance_encryption_at_rest_enabled" {
 query "sagemaker_notebook_instance_in_vpc" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'subnet_id') is not null then 'ok'
+        when (attributes_std -> 'subnet_id') is not null then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments -> 'subnet_id') is not null then ' in VPC'
+      address || case
+        when (attributes_std -> 'subnet_id') is not null then ' in VPC'
         else ' not in VPC'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -86,13 +86,13 @@ query "sagemaker_notebook_instance_in_vpc" {
 query "sagemaker_notebook_instance_root_access_disabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'root_access') = 'Disabled' then 'ok'
+        when (attributes_std ->> 'root_access') = 'Disabled' then 'ok'
         else 'alarm'
       end status,
-      name || case
-        when (arguments ->> 'root_access') = 'Disabled' then ' root access disabled'
+      address || case
+        when (attributes_std ->> 'root_access') = 'Disabled' then ' root access disabled'
         else ' root access enabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -107,13 +107,13 @@ query "sagemaker_notebook_instance_root_access_disabled" {
 query "sagemaker_domain_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when arguments -> 'kms_key_id' is not null then 'ok'
+        when attributes_std -> 'kms_key_id' is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when arguments -> 'kms_key_id' is not null then ' encrypted with KMS'
+      address || case
+        when attributes_std -> 'kms_key_id' is not null then ' encrypted with KMS'
         else ' not encrypted with KMS'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/secretsmanager.sp
+++ b/query/secretsmanager.sp
@@ -6,7 +6,7 @@ query "secretsmanager_secret_automatic_rotation_enabled" {
         when (attributes_std -> 'rotation_rules') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'rotation_rules') is null then ' automatic rotation disabled'
         else ' automatic rotation enabled'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "secretsmanager_secret_automatic_rotation_lambda_enabled" {
         when (attributes_std -> 'rotation_rules') is not null and (attributes_std -> 'rotation_lambda_arn') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'rotation_rules') is not null and (attributes_std -> 'rotation_lambda_arn') is not null then ' scheduled for rotation using Lambda function'
         else ' automatic rotation using Lambda function disabled'
       end || '.' as reason
@@ -51,7 +51,7 @@ query "secretsmanager_secret_encrypted_with_kms_cmk" {
         then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when coalesce(trim((attributes_std ->> 'kms_key_id')), '') = '' or
           (attributes_std ->> 'kms_key_id') = 'aws/secretsmanager'
         then ' is encrypted at rest default KMS key'

--- a/query/secretsmanager.sp
+++ b/query/secretsmanager.sp
@@ -1,13 +1,13 @@
 query "secretsmanager_secret_automatic_rotation_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'rotation_rules') is null then 'alarm'
+        when (attributes_std -> 'rotation_rules') is null then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'rotation_rules') is null then ' automatic rotation disabled'
+      address || case
+        when (attributes_std -> 'rotation_rules') is null then ' automatic rotation disabled'
         else ' automatic rotation enabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "secretsmanager_secret_automatic_rotation_enabled" {
 query "secretsmanager_secret_automatic_rotation_lambda_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'rotation_rules') is not null and (arguments -> 'rotation_lambda_arn') is not null then 'ok'
+        when (attributes_std -> 'rotation_rules') is not null and (attributes_std -> 'rotation_lambda_arn') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'rotation_rules') is not null and (arguments -> 'rotation_lambda_arn') is not null then ' scheduled for rotation using Lambda function'
+      address || case
+        when (attributes_std -> 'rotation_rules') is not null and (attributes_std -> 'rotation_lambda_arn') is not null then ' scheduled for rotation using Lambda function'
         else ' automatic rotation using Lambda function disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -44,16 +44,16 @@ query "secretsmanager_secret_automatic_rotation_lambda_enabled" {
 query "secretsmanager_secret_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when coalesce(trim((arguments ->> 'kms_key_id')), '') = '' or
-          (arguments ->> 'kms_key_id') = 'aws/secretsmanager'
+        when coalesce(trim((attributes_std ->> 'kms_key_id')), '') = '' or
+          (attributes_std ->> 'kms_key_id') = 'aws/secretsmanager'
         then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when coalesce(trim((arguments ->> 'kms_key_id')), '') = '' or
-          (arguments ->> 'kms_key_id') = 'aws/secretsmanager'
+      address || case
+        when coalesce(trim((attributes_std ->> 'kms_key_id')), '') = '' or
+          (attributes_std ->> 'kms_key_id') = 'aws/secretsmanager'
         then ' is encrypted at rest default KMS key'
         else ' is encrypted at rest using KMS CMK'
       end || '.' as reason

--- a/query/sfn.sp
+++ b/query/sfn.sp
@@ -6,7 +6,7 @@ query "sfn_state_machine_xray_tracing_enabled" {
         when (attributes_std -> 'tracing_configuration' ->> 'enabled') = 'true' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'tracing_configuration' ->> 'enabled') = 'true' then ' has tracing enabled'
         else ' has tracing disabled'
       end || '.' reason
@@ -27,7 +27,7 @@ query "sfn_state_machine_execution_history_logging_enabled" {
         when (attributes_std -> 'logging_configuration' ->> 'include_execution_data') = 'true' then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'logging_configuration' ->> 'include_execution_data') = 'true' then ' execution history logging enabled'
         else ' execution history logging disabled'
       end || '.' reason

--- a/query/sfn.sp
+++ b/query/sfn.sp
@@ -1,13 +1,13 @@
 query "sfn_state_machine_xray_tracing_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'tracing_configuration' ->> 'enabled') = 'true' then 'ok'
+        when (attributes_std -> 'tracing_configuration' ->> 'enabled') = 'true' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'tracing_configuration' ->> 'enabled') = 'true' then ' has tracing enabled'
+      address || case
+        when (attributes_std -> 'tracing_configuration' ->> 'enabled') = 'true' then ' has tracing enabled'
         else ' has tracing disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "sfn_state_machine_xray_tracing_enabled" {
 query "sfn_state_machine_execution_history_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logging_configuration' ->> 'include_execution_data') = 'true' then 'ok'
+        when (attributes_std -> 'logging_configuration' ->> 'include_execution_data') = 'true' then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'logging_configuration' ->> 'include_execution_data') = 'true' then ' execution history logging enabled'
+      address || case
+        when (attributes_std -> 'logging_configuration' ->> 'include_execution_data') = 'true' then ' execution history logging enabled'
         else ' execution history logging disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/sns.sp
+++ b/query/sns.sp
@@ -1,14 +1,14 @@
 query "sns_topic_encrypted_at_rest" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when coalesce(trim(arguments ->> 'kms_master_key_id'), '') = '' then 'alarm'
+        when coalesce(trim(attributes_std ->> 'kms_master_key_id'), '') = '' then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kms_master_key_id') is null then ' ''kms_master_key_id'' is not defined'
-        when coalesce(trim(arguments ->> 'kms_master_key_id'), '') <> '' then ' encryption at rest enabled'
+      address || case
+        when (attributes_std -> 'kms_master_key_id') is null then ' ''kms_master_key_id'' is not defined'
+        when coalesce(trim(attributes_std ->> 'kms_master_key_id'), '') <> '' then ' encryption at rest enabled'
         else ' encryption at rest disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -24,13 +24,13 @@ query "sns_topic_policy_restrict_public_access" {
   sql = <<-EOQ
      with sns_topic_public_policies as (
       select
-        distinct (type || ' ' || name ) as name
+        distinct (address ) as name
       from
         terraform_resource,
         jsonb_array_elements(
-          case when ((arguments ->> 'policy') = '')
+          case when ((attributes_std ->> 'policy') = '')
             then null
-            else ((arguments ->> 'policy')::jsonb -> 'Statement') end
+            else ((attributes_std ->> 'policy')::jsonb -> 'Statement') end
         ) as s
       where
         type = 'aws_sns_topic_policy'
@@ -45,12 +45,12 @@ query "sns_topic_policy_restrict_public_access" {
     select
       type || ' ' || r.name as resource,
       case
-        when (arguments ->> 'policy') = '' then 'ok'
+        when (attributes_std ->> 'policy') = '' then 'ok'
         when p.name is null then 'ok'
         else 'alarm'
       end status,
-      r.name || case
-        when (arguments ->> 'policy') = '' then ' no policy defined'
+      r.address || case
+        when (attributes_std ->> 'policy') = '' then ' no policy defined'
         when p.name is null then ' not publicly accessible'
         else ' publicly accessible'
       end || '.' reason

--- a/query/sqs.sp
+++ b/query/sqs.sp
@@ -1,15 +1,15 @@
 query "sqs_queue_encrypted_at_rest" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'kms_master_key_id') is null then 'alarm'
-        when coalesce(trim(arguments ->> 'kms_master_key_id'), '') = '' then 'alarm'
+        when (attributes_std -> 'kms_master_key_id') is null then 'alarm'
+        when coalesce(trim(attributes_std ->> 'kms_master_key_id'), '') = '' then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'kms_master_key_id') is null then ' ''kms_master_key_id'' is not defined'
-        when coalesce(trim(arguments ->> 'kms_master_key_id'), '') <> '' then ' encryption at rest enabled'
+      address || case
+        when (attributes_std -> 'kms_master_key_id') is null then ' ''kms_master_key_id'' is not defined'
+        when coalesce(trim(attributes_std ->> 'kms_master_key_id'), '') <> '' then ' encryption at rest enabled'
         else ' encryption at rest disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -24,17 +24,17 @@ query "sqs_queue_encrypted_at_rest" {
 query "sqs_vpc_endpoint_without_dns_resolution" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'service_name') like '%sqs%' and (arguments -> 'private_dns_enabled') is null then 'alarm'
-        when (arguments ->> 'service_name') like '%sqs%' and (arguments -> 'private_dns_enabled')::bool then 'ok'
-        when (arguments ->> 'service_name') like '%sqs%' and (arguments -> 'private_dns_enabled')::bool = false then 'alarm'
+        when (attributes_std ->> 'service_name') like '%sqs%' and (attributes_std -> 'private_dns_enabled') is null then 'alarm'
+        when (attributes_std ->> 'service_name') like '%sqs%' and (attributes_std -> 'private_dns_enabled')::bool then 'ok'
+        when (attributes_std ->> 'service_name') like '%sqs%' and (attributes_std -> 'private_dns_enabled')::bool = false then 'alarm'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'service_name') like '%sqs%' and (arguments -> 'private_dns_enabled') is null then ' private DNS disabled'
-        when (arguments ->> 'service_name') like '%sqs%' and (arguments -> 'private_dns_enabled')::bool then ' private DNS enabled'
-        when (arguments ->> 'service_name') like '%sqs%' and (arguments -> 'private_dns_enabled')::bool = false then ' private DNS disabled'
+      address || case
+        when (attributes_std ->> 'service_name') like '%sqs%' and (attributes_std -> 'private_dns_enabled') is null then ' private DNS disabled'
+        when (attributes_std ->> 'service_name') like '%sqs%' and (attributes_std -> 'private_dns_enabled')::bool then ' private DNS enabled'
+        when (attributes_std ->> 'service_name') like '%sqs%' and (attributes_std -> 'private_dns_enabled')::bool = false then ' private DNS disabled'
       end || '.' as reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}
@@ -48,13 +48,13 @@ query "sqs_vpc_endpoint_without_dns_resolution" {
 query "sqs_queue_policy_no_action_star" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Action": "*"}]' then 'alarm'
+        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Action": "*"}]' then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when ((arguments ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Action": "*"}]'  then ' policy allow wildcard action'
+      address || case
+        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Action": "*"}]'  then ' policy allow wildcard action'
         else ' policy is ok'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -69,13 +69,13 @@ query "sqs_queue_policy_no_action_star" {
 query "sqs_queue_policy_no_principal_star" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when ((arguments ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Principal": "*"}]' then 'alarm'
+        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Principal": "*"}]' then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when ((arguments ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Principal": "*"}]'  then ' policy allow all principal'
+      address || case
+        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Principal": "*"}]'  then ' policy allow all principal'
         else ' policy is ok'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/sqs.sp
+++ b/query/sqs.sp
@@ -7,7 +7,7 @@ query "sqs_queue_encrypted_at_rest" {
         when coalesce(trim(attributes_std ->> 'kms_master_key_id'), '') = '' then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'kms_master_key_id') is null then ' ''kms_master_key_id'' is not defined'
         when coalesce(trim(attributes_std ->> 'kms_master_key_id'), '') <> '' then ' encryption at rest enabled'
         else ' encryption at rest disabled'
@@ -31,7 +31,7 @@ query "sqs_vpc_endpoint_without_dns_resolution" {
         when (attributes_std ->> 'service_name') like '%sqs%' and (attributes_std -> 'private_dns_enabled')::bool = false then 'alarm'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'service_name') like '%sqs%' and (attributes_std -> 'private_dns_enabled') is null then ' private DNS disabled'
         when (attributes_std ->> 'service_name') like '%sqs%' and (attributes_std -> 'private_dns_enabled')::bool then ' private DNS enabled'
         when (attributes_std ->> 'service_name') like '%sqs%' and (attributes_std -> 'private_dns_enabled')::bool = false then ' private DNS disabled'
@@ -53,7 +53,7 @@ query "sqs_queue_policy_no_action_star" {
         when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Action": "*"}]' then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Action": "*"}]'  then ' policy allow wildcard action'
         else ' policy is ok'
       end || '.' as reason
@@ -74,7 +74,7 @@ query "sqs_queue_policy_no_principal_star" {
         when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Principal": "*"}]' then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Principal": "*"}]'  then ' policy allow all principal'
         else ' policy is ok'
       end || '.' as reason

--- a/query/sqs.sp
+++ b/query/sqs.sp
@@ -50,11 +50,11 @@ query "sqs_queue_policy_no_action_star" {
     select
       address as resource,
       case
-        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Action": "*"}]' then 'alarm'
+        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement' @> '[{"Action": "*"}]' then 'alarm'
         else 'ok'
       end as status,
       split_part(address, '.', 2) || case
-        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Action": "*"}]'  then ' policy allow wildcard action'
+        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement' @> '[{"Action": "*"}]' then ' policy allow wildcard action'
         else ' policy is ok'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -71,11 +71,11 @@ query "sqs_queue_policy_no_principal_star" {
     select
       address as resource,
       case
-        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Principal": "*"}]' then 'alarm'
+        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement' @> '[{"Principal": "*"}]' then 'alarm'
         else 'ok'
       end as status,
       split_part(address, '.', 2) || case
-        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement'  @> '[{"Principal": "*"}]'  then ' policy allow all principal'
+        when ((attributes_std ->> 'policy')::jsonb ) -> 'Statement' @> '[{"Principal": "*"}]' then ' policy allow all principal'
         else ' policy is ok'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/ssm.sp
+++ b/query/ssm.sp
@@ -6,7 +6,7 @@ query "ssm_document_prohibit_public_access" {
         when (attributes_std -> 'permissions' ->> 'account_ids') = 'All' then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'permissions' ->> 'account_ids') = 'All' then ' is publicly accessible'
         else ' not publicly accessible'
       end || '.' reason
@@ -27,7 +27,7 @@ query "ssm_parameter_encrypted_with_kms_cmk" {
         when attributes_std -> 'key_id' is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when attributes_std -> 'key_id' is not null then ' encrypted with KMS'
         else ' not encrypted with KMS'
       end || '.' as reason

--- a/query/ssm.sp
+++ b/query/ssm.sp
@@ -1,13 +1,13 @@
 query "ssm_document_prohibit_public_access" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'permissions' ->> 'account_ids') = 'All' then 'alarm'
+        when (attributes_std -> 'permissions' ->> 'account_ids') = 'All' then 'alarm'
         else 'ok'
       end as status,
-      name || case
-        when (arguments -> 'permissions' ->> 'account_ids') = 'All' then ' is publicly accessible'
+      address || case
+        when (attributes_std -> 'permissions' ->> 'account_ids') = 'All' then ' is publicly accessible'
         else ' not publicly accessible'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "ssm_document_prohibit_public_access" {
 query "ssm_parameter_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when arguments -> 'key_id' is not null then 'ok'
+        when attributes_std -> 'key_id' is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when arguments -> 'key_id' is not null then ' encrypted with KMS'
+      address || case
+        when attributes_std -> 'key_id' is not null then ' encrypted with KMS'
         else ' not encrypted with KMS'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/timestream.sp
+++ b/query/timestream.sp
@@ -1,13 +1,13 @@
 query "timestream_database_encrypted_with_kms_cmk" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'kms_key_id') is not null then 'ok'
+        when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'kms_key_id') is not null then ' encrypted with KMS'
+      address || case
+        when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with KMS'
         else ' not encrypted with KMS'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/timestream.sp
+++ b/query/timestream.sp
@@ -6,7 +6,7 @@ query "timestream_database_encrypted_with_kms_cmk" {
         when (attributes_std ->> 'kms_key_id') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'kms_key_id') is not null then ' encrypted with KMS'
         else ' not encrypted with KMS'
       end || '.' reason

--- a/query/vpc.sp
+++ b/query/vpc.sp
@@ -240,7 +240,7 @@ query "vpc_transfer_server_not_publicly_accesible" {
       end status,
       split_part(address, '.', 2) || case
         when (attributes_std -> 'endpoint_type') is null then ' publicly accessible'
-        when (attributes_std ->> 'endpoint_type') in ('VPC', 'VPC_ENDPOINT')  then ' not publicly accessible'
+        when (attributes_std ->> 'endpoint_type') in ('VPC', 'VPC_ENDPOINT') then ' not publicly accessible'
         else ' publicly accessible'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/vpc.sp
+++ b/query/vpc.sp
@@ -7,10 +7,10 @@ query "vpc_default_security_group_restricts_all_traffic" {
         else 'alarm'
       end as status,
       case
-        when (attributes_std -> 'ingress') is not null and (attributes_std -> 'egress') is not null then 'Default security group ' || name || ' has inbound and outbound rules'
-        when (attributes_std -> 'ingress') is not null and (attributes_std -> 'egress') is null then 'Default security group ' || name || ' has inbound rules'
-        when (attributes_std -> 'ingress') is null and (attributes_std -> 'egress') is not null then 'Default security group ' || name || ' has outbound rules'
-        else 'Default security group ' || name || ' has no inbound or outbound rules'
+        when (attributes_std -> 'ingress') is not null and (attributes_std -> 'egress') is not null then 'Default security group ' || split_part(address, '.', 2) || ' has inbound and outbound rules'
+        when (attributes_std -> 'ingress') is not null and (attributes_std -> 'egress') is null then 'Default security group ' || split_part(address, '.', 2) || ' has inbound rules'
+        when (attributes_std -> 'ingress') is null and (attributes_std -> 'egress') is not null then 'Default security group ' || split_part(address, '.', 2) || ' has outbound rules'
+        else 'Default security group ' || split_part(address, '.', 2) || ' has no inbound or outbound rules'
       end || '.' as reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}
@@ -30,7 +30,7 @@ query "vpc_eip_associated" {
         when (attributes_std -> 'instance') is not null or (attributes_std -> 'network_interface') is not null then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'vpc') is null then ' not associated with VPC'
         when (attributes_std -> 'instance') is not null or (attributes_std -> 'network_interface') is not null then ' associated with an instance or network interface'
         else ' not associated with an instance or network interface'
@@ -62,12 +62,12 @@ query "vpc_flow_logs_enabled" {
           type = 'aws_vpc'
     )
     select
-      a.type || ' ' || a.name as resource,
+      a.address as resource,
       case
         when b.flow_log_vpc_id is not null then 'ok'
         else 'alarm'
       end as status,
-      a.address || case
+      split_part(a.address, '.', 2) || case
         when b.flow_log_vpc_id is not null then ' flow logging enabled'
         else ' flow logging disabled'
       end || '.' reason
@@ -87,7 +87,7 @@ query "vpc_igw_attached_to_authorized_vpc" {
         when name in (select split_part((attributes_std ->> 'vpc_id')::text, '.', 2) from terraform_resource where type = 'aws_internet_gateway') then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
       when name in (select split_part((attributes_std ->> 'vpc_id')::text, '.', 2) from terraform_resource where type = 'aws_internet_gateway') then ' has internet gateway attachment(s)'
       else ' has no internet gateway attachment(s)'
       end || '.' as reason
@@ -108,7 +108,7 @@ query "vpc_network_acl_unused" {
         when (attributes_std -> 'subnet_ids') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'subnet_ids') is null then ' not associated with subnets'
         else ' associated with ' || (jsonb_array_length(attributes_std -> 'subnet_ids')) || ' subnet(s)'
       end || '.' as reason
@@ -129,7 +129,7 @@ query "vpc_security_group_associated_to_eni" {
         when name in (select split_part((jsonb_array_elements(attributes_std -> 'security_groups')::text), '.', 2) from terraform_resource where type = 'aws_network_interface') then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
       when name in (select split_part((jsonb_array_elements(attributes_std -> 'security_groups')::text), '.', 2) from terraform_resource where type = 'aws_network_interface') then ' has attached ENI(s)'
       else ' has no attached ENI(s)'
       end || '.' as reason
@@ -150,7 +150,7 @@ query "vpc_security_group_description_for_rules" {
         when (attributes_std -> 'description') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'description') is null then ' no description defined'
         else ' description defined'
       end || '.' reason
@@ -171,7 +171,7 @@ query "vpc_security_group_rule_description_for_rules" {
         when (attributes_std -> 'description') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'description') is null then ' no description defined'
         else ' description defined'
       end || '.' reason
@@ -192,7 +192,7 @@ query "vpc_subnet_auto_assign_public_ip_disabled" {
         when (attributes_std ->> 'map_public_ip_on_launch')::boolean then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'map_public_ip_on_launch') is null then ' ''map_public_ip_on_launch'' disabled'
         when (attributes_std ->> 'map_public_ip_on_launch')::boolean then ' ''map_public_ip_on_launch'' enabled'
         else ' ''map_public_ip_on_launch'' disabled'
@@ -215,7 +215,7 @@ query "vpc_endpoint_service_acceptance_enabled" {
         when (attributes_std ->> 'acceptance_required')::boolean then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'acceptance_required') is null then ' ''acceptance_required'' not defined'
         when (attributes_std ->> 'acceptance_required')::boolean then ' ''acceptance_required'' enabled'
         else ' ''acceptance_required'' disabled'
@@ -238,7 +238,7 @@ query "vpc_transfer_server_not_publicly_accesible" {
         when (attributes_std ->> 'endpoint_type') in ('VPC', 'VPC_ENDPOINT') then 'ok'
         else 'alarm'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'endpoint_type') is null then ' publicly accessible'
         when (attributes_std ->> 'endpoint_type') in ('VPC', 'VPC_ENDPOINT')  then ' not publicly accessible'
         else ' publicly accessible'
@@ -261,7 +261,7 @@ query "vpc_network_firewall_encrypted_with_kms_cmk" {
         when (attributes_std -> 'encryption_configuration' ->> 'key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encryption_configuration' ->> 'key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' reason
@@ -282,7 +282,7 @@ query "vpc_network_firewall_rule_group_encrypted_with_kms_cmk" {
         when (attributes_std -> 'encryption_configuration' ->> 'key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encryption_configuration' ->> 'key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' reason
@@ -303,7 +303,7 @@ query "vpc_network_firewall_policy_encrypted_with_kms_cmk" {
         when (attributes_std -> 'encryption_configuration' ->> 'key_id') is null then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'encryption_configuration' ->> 'key_id') is null then ' not encrypted with KMS CMK'
         else ' encrypted with KMS CMK'
       end || '.' reason
@@ -324,7 +324,7 @@ query "vpc_network_firewall_deletion_protection_enabled" {
         when (attributes_std ->> 'delete_protection')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'delete_protection')::boolean is null then ' deletion protection not set'
         when (attributes_std ->> 'delete_protection')::boolean then ' deletion protection enabled'
         else ' deletion protection disabled'
@@ -346,7 +346,7 @@ query "vpc_ec2_transit_gateway_auto_accept_attachment_requests_disabled" {
         when (attributes_std ->> 'auto_accept_shared_attachments') = 'enable' then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'auto_accept_shared_attachments') = 'enable' then ' automatically accept VPC attachment requests'
         else ' do not automatically accept VPC attachment requests'
       end || '.' reason
@@ -363,7 +363,7 @@ query "vpc_network_acl_allow_ftp_port_20_ingress" {
   sql = <<-EOQ
     with rules as (
       select distinct
-        name
+        address as name
       from
         terraform_resource,
         jsonb_array_elements(
@@ -384,12 +384,12 @@ query "vpc_network_acl_allow_ftp_port_20_ingress" {
         )
     )
     select
-      type || ' ' || r.name as resource,
+      r.address as resource,
       case
         when g.name is null then 'ok'
         else 'alarm'
       end as status,
-      r.address || case
+      split_part(r.address, '.', 2) || case
         when g.name is null then ' restricts FTP data port 20 access from the internet'
         else ' allows FTP data port 20 access from the internet'
       end || '.' reason
@@ -397,7 +397,7 @@ query "vpc_network_acl_allow_ftp_port_20_ingress" {
       ${local.common_dimensions_sql}
     from
       terraform_resource as r
-      left join rules as g on g.name = r.name
+      left join rules as g on g.name = r.address
     where
       type = 'aws_network_acl';
   EOQ
@@ -407,7 +407,7 @@ query "vpc_network_acl_allow_ftp_port_21_ingress" {
   sql = <<-EOQ
     with rules as (
       select distinct
-        name
+        address as name
       from
         terraform_resource,
         jsonb_array_elements(
@@ -428,12 +428,12 @@ query "vpc_network_acl_allow_ftp_port_21_ingress" {
         )
     )
     select
-      type || ' ' || r.name as resource,
+      r.address as resource,
       case
         when g.name is null then 'ok'
         else 'alarm'
       end as status,
-      r.address || case
+      split_part(r.address, '.', 2) || case
         when g.name is null then ' restricts FTP port 21 access from the internet'
         else ' allows FTP port 21 access from the internet'
       end || '.' reason
@@ -441,7 +441,7 @@ query "vpc_network_acl_allow_ftp_port_21_ingress" {
       ${local.common_dimensions_sql}
     from
       terraform_resource as r
-      left join rules as g on g.name = r.name
+      left join rules as g on g.name = r.address
     where
       type = 'aws_network_acl';
   EOQ
@@ -451,7 +451,7 @@ query "vpc_network_acl_allow_ssh_port_22_ingress" {
   sql = <<-EOQ
     with rules as (
       select distinct
-        name
+        address as name
       from
         terraform_resource,
         jsonb_array_elements(
@@ -472,12 +472,12 @@ query "vpc_network_acl_allow_ssh_port_22_ingress" {
         )
     )
     select
-      type || ' ' || r.name as resource,
+      r.address as resource,
       case
         when g.name is null then 'ok'
         else 'alarm'
       end as status,
-      r.address || case
+      split_part(r.address, '.', 2) || case
         when g.name is null then ' restricts SSH access from the internet through port 22'
         else ' allows SSH access from the internet through port 22'
       end || '.' reason
@@ -485,7 +485,7 @@ query "vpc_network_acl_allow_ssh_port_22_ingress" {
       ${local.common_dimensions_sql}
     from
       terraform_resource as r
-      left join rules as g on g.name = r.name
+      left join rules as g on g.name = r.address
     where
       type = 'aws_network_acl';
   EOQ
@@ -495,7 +495,7 @@ query "vpc_network_acl_allow_rdp_port_3389_ingress" {
   sql = <<-EOQ
     with rules as (
       select distinct
-        name
+        address as name
       from
         terraform_resource,
         jsonb_array_elements(
@@ -516,12 +516,12 @@ query "vpc_network_acl_allow_rdp_port_3389_ingress" {
         )
     )
     select
-      type || ' ' || r.name as resource,
+      r.address as resource,
       case
         when g.name is null then 'ok'
         else 'alarm'
       end as status,
-      r.address || case
+      split_part(r.address, '.', 2) || case
         when g.name is null then ' restricts RDP access from the internet through port 3389'
         else ' allows RDP access from the internet through port 3389'
       end || '.' reason
@@ -529,7 +529,7 @@ query "vpc_network_acl_allow_rdp_port_3389_ingress" {
       ${local.common_dimensions_sql}
     from
       terraform_resource as r
-      left join rules as g on g.name = r.name
+      left join rules as g on g.name = r.address
     where
       type = 'aws_network_acl';
   EOQ
@@ -544,7 +544,7 @@ query "vpc_network_acl_rule_restrict_ingress_ports_all" {
         when (attributes_std ->> 'rule_action') = 'allow' and (attributes_std -> 'from_port') is null then 'alarm'
         else 'ok'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'egress') = 'true' then ' is egress rule'
         when (attributes_std ->> 'rule_action') = 'allow' and (attributes_std -> 'from_port') is null then ' allows access to all ports'
         else ' restricts access to all ports'
@@ -565,7 +565,7 @@ query "vpc_transfer_server_allows_only_secure_protocols" {
         when (attributes_std -> 'protocols') @> '["FTP"]' then 'alarm'
         else 'ok'
       end status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'protocols') @> '["FTP"]' then ' allows unsecure protocols'
         else ' allows only secure protocols'
       end || '.' reason

--- a/query/waf.sp
+++ b/query/waf.sp
@@ -6,7 +6,7 @@ query "waf_web_acl_rule_attached" {
         when (attributes_std -> 'rules') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'rules') is not null then ' has rule(s) attached'
         else ' has no attached rules'
       end || '.' reason
@@ -27,7 +27,7 @@ query "waf_regional_web_acl_rule_attached" {
         when (attributes_std -> 'rule') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'rule') is not null then ' has rule(s) attached'
         else ' has no attached rules'
       end || '.' reason
@@ -48,7 +48,7 @@ query "waf_web_acl_logging_enabled" {
         when (attributes_std -> 'logging_configuration' ->> 'log_destination') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'logging_configuration' ->> 'log_destination') is not null then ' logging enabled'
         else ' logging disabled'
       end || '.' reason
@@ -69,7 +69,7 @@ query "waf_regional_web_acl_logging_enabled" {
         when (attributes_std -> 'logging_configuration' ->> 'log_destination') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'logging_configuration' ->> 'log_destination' ) is not null then ' logging enabled'
         else ' logging disabled'
       end || '.' reason
@@ -99,14 +99,14 @@ query "waf_web_acl_rule_with_action" {
         and type = 'aws_waf_web_acl'
     )
     select
-      r.type || ' ' || r.name as resource,
+      r.address as resource,
       case
         when (jsonb_typeof(attributes_std -> 'rules') = 'array') and a.name is null then 'ok'
         when (jsonb_typeof(attributes_std -> 'rules') = 'array') and a.name is not null then 'alarm'
         when (attributes_std -> 'rules' ->> 'action') is not null then 'ok'
         else 'alarm'
       end as status,
-      r.address || case
+      split_part(r.address, '.', 2) || case
         when (jsonb_typeof(attributes_std -> 'rules') = 'array') and a.name is null then ' has all rules with action attached'
         when (jsonb_typeof(attributes_std -> 'rules') = 'array') and a.name is not null then ' has rules with no action attached'
         when (attributes_std -> 'rules' ->> 'action') is not null then ' has rule with action attached'
@@ -116,7 +116,7 @@ query "waf_web_acl_rule_with_action" {
       ${local.common_dimensions_sql}
     from
       terraform_resource as r
-      left join rules_without_action as a on a.name = concat(r.type || ' ' || r.name)
+      left join rules_without_action as a on a.name = r.address
     where
       r.type = 'aws_waf_web_acl';
   EOQ
@@ -139,14 +139,14 @@ query "waf_regional_web_acl_rule_with_action" {
         and type = 'aws_wafregional_web_acl'
     )
     select
-      r.type || ' ' || r.name as resource,
+      r.address as resource,
       case
         when (jsonb_typeof(attributes_std -> 'rule') = 'array') and a.name is null then 'ok'
         when (jsonb_typeof(attributes_std -> 'rule') = 'array') and a.name is not null then 'alarm'
         when ((attributes_std -> 'rule' ->> 'action') is not null) then 'ok'
         else 'alarm'
       end as status,
-      r.address || case
+      split_part(r.address, '.', 2) || case
         when (jsonb_typeof(attributes_std -> 'rule') = 'array') and a.name is null then ' has all rules with action attached'
         when (jsonb_typeof(attributes_std -> 'rule') = 'array') and a.name is not null then ' has rules with no action attached'
         when ((attributes_std -> 'rule' ->> 'action') is not null) then ' has rule with action attached'
@@ -156,7 +156,7 @@ query "waf_regional_web_acl_rule_with_action" {
       ${local.common_dimensions_sql}
     from
       terraform_resource as r
-      left join rules_without_action as a on a.name = concat(r.type || ' ' || r.name)
+      left join rules_without_action as a on a.name = r.address
     where
       r.type = 'aws_wafregional_web_acl';
   EOQ

--- a/query/waf.sp
+++ b/query/waf.sp
@@ -1,13 +1,13 @@
 query "waf_web_acl_rule_attached" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'rules') is not null then 'ok'
+        when (attributes_std -> 'rules') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'rules') is not null then ' has rule(s) attached'
+      address || case
+        when (attributes_std -> 'rules') is not null then ' has rule(s) attached'
         else ' has no attached rules'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "waf_web_acl_rule_attached" {
 query "waf_regional_web_acl_rule_attached" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'rule') is not null then 'ok'
+        when (attributes_std -> 'rule') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'rule') is not null then ' has rule(s) attached'
+      address || case
+        when (attributes_std -> 'rule') is not null then ' has rule(s) attached'
         else ' has no attached rules'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -43,13 +43,13 @@ query "waf_regional_web_acl_rule_attached" {
 query "waf_web_acl_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logging_configuration' ->> 'log_destination') is not null then 'ok'
+        when (attributes_std -> 'logging_configuration' ->> 'log_destination') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'logging_configuration' ->> 'log_destination') is not null then ' logging enabled'
+      address || case
+        when (attributes_std -> 'logging_configuration' ->> 'log_destination') is not null then ' logging enabled'
         else ' logging disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -64,13 +64,13 @@ query "waf_web_acl_logging_enabled" {
 query "waf_regional_web_acl_logging_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'logging_configuration' ->> 'log_destination') is not null then 'ok'
+        when (attributes_std -> 'logging_configuration' ->> 'log_destination') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'logging_configuration' ->> 'log_destination' ) is not null then ' logging enabled'
+      address || case
+        when (attributes_std -> 'logging_configuration' ->> 'log_destination' ) is not null then ' logging enabled'
         else ' logging disabled'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -86,12 +86,12 @@ query "waf_web_acl_rule_with_action" {
   sql = <<-EOQ
     with rules_without_action as (
       select
-        type || ' ' || name as name
+        address as name
       from
         terraform_resource,
         jsonb_array_elements(
-        case jsonb_typeof(arguments -> 'rules')
-          when 'array' then (arguments -> 'rules')
+        case jsonb_typeof(attributes_std -> 'rules')
+          when 'array' then (attributes_std -> 'rules')
           else null end
         ) as r
       where
@@ -101,15 +101,15 @@ query "waf_web_acl_rule_with_action" {
     select
       r.type || ' ' || r.name as resource,
       case
-        when (jsonb_typeof(arguments -> 'rules') = 'array') and a.name is null then 'ok'
-        when (jsonb_typeof(arguments -> 'rules') = 'array') and a.name is not null then 'alarm'
-        when (arguments -> 'rules' ->> 'action') is not null then 'ok'
+        when (jsonb_typeof(attributes_std -> 'rules') = 'array') and a.name is null then 'ok'
+        when (jsonb_typeof(attributes_std -> 'rules') = 'array') and a.name is not null then 'alarm'
+        when (attributes_std -> 'rules' ->> 'action') is not null then 'ok'
         else 'alarm'
       end as status,
-      r.name || case
-        when (jsonb_typeof(arguments -> 'rules') = 'array') and a.name is null then ' has all rules with action attached'
-        when (jsonb_typeof(arguments -> 'rules') = 'array') and a.name is not null then ' has rules with no action attached'
-        when (arguments -> 'rules' ->> 'action') is not null then ' has rule with action attached'
+      r.address || case
+        when (jsonb_typeof(attributes_std -> 'rules') = 'array') and a.name is null then ' has all rules with action attached'
+        when (jsonb_typeof(attributes_std -> 'rules') = 'array') and a.name is not null then ' has rules with no action attached'
+        when (attributes_std -> 'rules' ->> 'action') is not null then ' has rule with action attached'
         else ' has rules with no action attached'
       end || '.' reason
       ${local.tag_dimensions_sql}
@@ -126,12 +126,12 @@ query "waf_regional_web_acl_rule_with_action" {
   sql = <<-EOQ
     with rules_without_action as (
       select
-        type || ' ' || name as name
+        address as name
       from
         terraform_resource,
         jsonb_array_elements(
-        case jsonb_typeof(arguments -> 'rule')
-          when 'array' then (arguments -> 'rule')
+        case jsonb_typeof(attributes_std -> 'rule')
+          when 'array' then (attributes_std -> 'rule')
           else null end
         ) as r
       where
@@ -141,15 +141,15 @@ query "waf_regional_web_acl_rule_with_action" {
     select
       r.type || ' ' || r.name as resource,
       case
-        when (jsonb_typeof(arguments -> 'rule') = 'array') and a.name is null then 'ok'
-        when (jsonb_typeof(arguments -> 'rule') = 'array') and a.name is not null then 'alarm'
-        when ((arguments -> 'rule' ->> 'action') is not null) then 'ok'
+        when (jsonb_typeof(attributes_std -> 'rule') = 'array') and a.name is null then 'ok'
+        when (jsonb_typeof(attributes_std -> 'rule') = 'array') and a.name is not null then 'alarm'
+        when ((attributes_std -> 'rule' ->> 'action') is not null) then 'ok'
         else 'alarm'
       end as status,
-      r.name || case
-        when (jsonb_typeof(arguments -> 'rule') = 'array') and a.name is null then ' has all rules with action attached'
-        when (jsonb_typeof(arguments -> 'rule') = 'array') and a.name is not null then ' has rules with no action attached'
-        when ((arguments -> 'rule' ->> 'action') is not null) then ' has rule with action attached'
+      r.address || case
+        when (jsonb_typeof(attributes_std -> 'rule') = 'array') and a.name is null then ' has all rules with action attached'
+        when (jsonb_typeof(attributes_std -> 'rule') = 'array') and a.name is not null then ' has rules with no action attached'
+        when ((attributes_std -> 'rule' ->> 'action') is not null) then ' has rule with action attached'
         else ' has rules with no action attached'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/wafv2.sp
+++ b/query/wafv2.sp
@@ -6,7 +6,7 @@ query "wafv2_web_acl_rule_attached" {
         when (attributes_std -> 'rule') is not null then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std -> 'rule') is not null then ' has rule(s) attached'
         else ' has no attached rules'
       end || '.' reason

--- a/query/wafv2.sp
+++ b/query/wafv2.sp
@@ -1,13 +1,13 @@
 query "wafv2_web_acl_rule_attached" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments -> 'rule') is not null then 'ok'
+        when (attributes_std -> 'rule') is not null then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments -> 'rule') is not null then ' has rule(s) attached'
+      address || case
+        when (attributes_std -> 'rule') is not null then ' has rule(s) attached'
         else ' has no attached rules'
       end || '.' reason
       ${local.tag_dimensions_sql}

--- a/query/workspace.sp
+++ b/query/workspace.sp
@@ -1,13 +1,13 @@
 query "workspace_root_volume_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'user_volume_encryption_enabled')::boolean then 'ok'
+        when (attributes_std ->> 'user_volume_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'user_volume_encryption_enabled')::boolean then ' encrypted at rest'
+      address || case
+        when (attributes_std ->> 'user_volume_encryption_enabled')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason
       ${local.tag_dimensions_sql}
@@ -22,13 +22,13 @@ query "workspace_root_volume_encryption_at_rest_enabled" {
 query "workspace_user_volume_encryption_at_rest_enabled" {
   sql = <<-EOQ
     select
-      type || ' ' || name as resource,
+      address as resource,
       case
-        when (arguments ->> 'root_volume_encryption_enabled')::boolean then 'ok'
+        when (attributes_std ->> 'root_volume_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end as status,
-      name || case
-        when (arguments ->> 'root_volume_encryption_enabled')::boolean then ' encrypted at rest'
+      address || case
+        when (attributes_std ->> 'root_volume_encryption_enabled')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason
       ${local.tag_dimensions_sql}

--- a/query/workspace.sp
+++ b/query/workspace.sp
@@ -6,7 +6,7 @@ query "workspace_root_volume_encryption_at_rest_enabled" {
         when (attributes_std ->> 'user_volume_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'user_volume_encryption_enabled')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason
@@ -27,7 +27,7 @@ query "workspace_user_volume_encryption_at_rest_enabled" {
         when (attributes_std ->> 'root_volume_encryption_enabled')::boolean then 'ok'
         else 'alarm'
       end as status,
-      address || case
+      split_part(address, '.', 2) || case
         when (attributes_std ->> 'root_volume_encryption_enabled')::boolean then ' encrypted at rest'
         else ' not encrypted at rest'
       end || '.' as reason


### PR DESCRIPTION
**Before**

```
Summary 

OK .................... 454 [====      ]
SKIP ..................... 44 [=         ]
INFO .......................... 2 [=         ]
ALARM .................... 856 [=======   ]
ERROR .................. 0 [          ]
TOTAL .................. 856 / 1356[==========]

> select count(*) from terraform_resource where type like '%aws%'
+-------+
| count |
+-------+
| 596   |
+-------+"
Used set of TF files
```

**After**

```
Summary

OK .................... 454 [====      ]
SKIP ..................... 44 [=         ]
INFO .......................... 2 [=         ]
ALARM .................... 856 [=======   ]
ERROR .................. 0 [          ]
TOTAL .................. 856 / 1356[==========]

> select count(*) from terraform_resource where type like '%aws%'
+-------+
| count |
+-------+
| 596   |
+-------+"
```
